### PR TITLE
Make sure users know that this version is Python 3 only

### DIFF
--- a/gsw/__init__.py
+++ b/gsw/__init__.py
@@ -45,4 +45,4 @@ from . import ice
 
 from .conversions import t90_from_t68
 
-__version__ = "3.1.0"
+__version__ = "3.1.1"

--- a/setup.py
+++ b/setup.py
@@ -77,8 +77,8 @@ config = dict(
     description='Gibbs Seawater Oceanographic Package of TEOS-10',
     long_description=long_description,
     license=LICENSE,
-    # url='https://github.com/TEOS-10/GSW-python',
-    # download_url='https://pypi.python.org/pypi/gsw/',
+    url='https://github.com/TEOS-10/GSW-python',
+    download_url='https://pypi.python.org/pypi/gsw/',
     classifiers=[
         'Development Status :: 4 - alpha',
         'Environment :: Console',

--- a/setup.py
+++ b/setup.py
@@ -39,7 +39,7 @@ Python {py} detected.
     print(error, file=sys.stderr)
     sys.exit(1)
 
-if sys.platform == 'win32':
+if os.name in ('nt', 'dos'):
     srcdir = 'src2'
     c_ext = 'cpp'
 else:

--- a/setup.py
+++ b/setup.py
@@ -1,11 +1,43 @@
 '''
 Minimal setup.py for building gswc.
 '''
-import os, sys
+
+from __future__ import print_function
+
+import os
+import sys
 
 from setuptools import Extension, setup
 
 import numpy as np
+
+# Check Python version.
+if sys.version_info < (3, 4):
+    pip_message = ('This may be due to an out of date pip. '
+                   'Make sure you have pip >= 9.0.1.')
+    try:
+        import pip
+        pip_version = tuple([int(x) for x in pip.__version__.split('.')[:3]])
+        if pip_version < (9, 0, 1):
+            pip_message = ('Your pip version is out of date, '
+                           'please install pip >= 9.0.1. '
+                           'pip {} detected.').format(pip.__version__)
+        else:
+            # pip is new enough - it must be something else.
+            pip_message = ''
+    except Exception:
+        pass
+
+    error = """
+Latest gsw does not support Python 2.x, 3.0, 3.1, 3.2 or 3.3.
+When using Python 2.7 please install the last pure Python version
+of gsw available at PyPI (3.0.6).
+Python {py} detected.
+{pip}
+""".format(py=sys.version_info, pip=pip_message)
+
+    print(error, file=sys.stderr)
+    sys.exit(1)
 
 if sys.platform == 'win32':
     srcdir = 'src2'
@@ -47,19 +79,19 @@ config = dict(
     license=LICENSE,
     # url='https://github.com/TEOS-10/GSW-python',
     # download_url='https://pypi.python.org/pypi/gsw/',
-    classifiers=['Development Status :: 4 - Beta',
-               'Environment :: Console',
-               'Intended Audience :: Science/Research',
-               'Intended Audience :: Developers',
-               'Intended Audience :: Education',
-               'License :: OSI Approved :: MIT License',
-               'Operating System :: OS Independent',
-               'Programming Language :: Python',
-               'Programming Language :: Python :: 3.5',
-               'Programming Language :: Python :: 3.6',
-               'Topic :: Education',
-               'Topic :: Scientific/Engineering',
-               ],
+    classifiers=[
+        'Development Status :: 4 - alpha',
+        'Environment :: Console',
+        'Intended Audience :: Science/Research',
+        'License :: OSI Approved :: MIT License',
+        'Operating System :: OS Independent',
+        'Programming Language :: Python',
+        'Programming Language :: Python :: 3 :: Only',
+        'Programming Language :: Python :: 3.4',
+        'Programming Language :: Python :: 3.5',
+        'Programming Language :: Python :: 3.6',
+        'Topic :: Scientific/Engineering',
+    ],
     python_requires='>=3.5',
     platforms='any',
     keywords=['oceanography', 'seawater', 'TEOS-10'],

--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,7 @@ from setuptools import Extension, setup
 import numpy as np
 
 # Check Python version.
-if sys.version_info < (3, 4):
+if sys.version_info < (3, 5):
     pip_message = ('This may be due to an out of date pip. '
                    'Make sure you have pip >= 9.0.1.')
     try:
@@ -29,7 +29,7 @@ if sys.version_info < (3, 4):
         pass
 
     error = """
-Latest gsw does not support Python 2.x, 3.0, 3.1, 3.2 or 3.3.
+Latest gsw does not support Python < 3.5.
 When using Python 2.7 please install the last pure Python version
 of gsw available at PyPI (3.0.6).
 Python {py} detected.
@@ -87,7 +87,6 @@ config = dict(
         'Operating System :: OS Independent',
         'Programming Language :: Python',
         'Programming Language :: Python :: 3 :: Only',
-        'Programming Language :: Python :: 3.4',
         'Programming Language :: Python :: 3.5',
         'Programming Language :: Python :: 3.6',
         'Topic :: Scientific/Engineering',


### PR DESCRIPTION
@efiring I would like to get a new release after this because I just got a few dozens of e-mails from Python 2.7 user confused with the error message when trying to install latest `gsw` (and 1 user that could not build it from source on Windows using `cygwin` and `gcc` because of the `sys.platform == 'win32'`).