### PR TITLE
Drop testing with numpy 1.11 and add numpy 1.13

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,18 +10,18 @@ matrix:
   fast_finish: true
   include:
   - python: 3.5
-    env: TEST_TARGET=default NUMPY=1.11
+    env: TEST_TARGET=default NUMPY=1.12
   - python: 3.5
-    env: TEST_TARGET=default NUMPY=1.12
-  - python: 3.6
-    env: TEST_TARGET=default NUMPY=1.11
+    env: TEST_TARGET=default NUMPY=1.13
   - python: 3.6
     env: TEST_TARGET=default NUMPY=1.12
   - python: 3.6
-    env: TEST_TARGET=publish NUMPY=1.12
+    env: TEST_TARGET=default NUMPY=1.13
+  - python: 3.6
+    env: TEST_TARGET=publish NUMPY=1.13
   allow_failures:
   - python: 3.6
-    env: TEST_TARGET=publish NUMPY=1.12
+    env: TEST_TARGET=publish NUMPY=1.13
 
 before_install:
     - wget http://bit.ly/miniconda -O miniconda.sh

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -2,22 +2,22 @@ environment:
   matrix:
     - TARGET_ARCH: x64
       CONDA_PY: 35
-      CONDA_NPY: 111
+      CONDA_NPY: 112
       CONDA_INSTALL_LOCN: C:\\Miniconda35-x64
 
     - TARGET_ARCH: x64
       CONDA_PY: 35
-      CONDA_NPY: 112
+      CONDA_NPY: 113
       CONDA_INSTALL_LOCN: C:\\Miniconda35-x64
 
     - TARGET_ARCH: x64
       CONDA_PY: 36
-      CONDA_NPY: 111
+      CONDA_NPY: 112
       CONDA_INSTALL_LOCN: C:\\Miniconda36-x64
 
     - TARGET_ARCH: x64
       CONDA_PY: 36
-      CONDA_NPY: 112
+      CONDA_NPY: 113
       CONDA_INSTALL_LOCN: C:\\Miniconda36-x64
 
 platform:


### PR DESCRIPTION
Nothing new. Just test the code against latest `numpy` and drop the older one to avoid increasing the test time.