### PR TITLE
Fix bug in pchip_interp utility function.

### DIFF
--- a/gsw/tests/test_check_functions.py
+++ b/gsw/tests/test_check_functions.py
@@ -12,6 +12,10 @@ import gsw
 from gsw._utilities import Bunch
 from check_functions import parse_check_functions
 
+# Most of the tests have some nan values, so we need to suppress the warning.
+# Any more careful fix would likely require considerable effort.
+np.seterr(invalid='ignore')
+
 root_path = os.path.abspath(os.path.dirname(__file__))
 
 # Function checks that we can't handle automatically yet.

--- a/gsw/tests/test_utility.py
+++ b/gsw/tests/test_utility.py
@@ -1,0 +1,28 @@
+import pytest
+
+import numpy as np
+
+import gsw
+
+nx, ny, nz = 2, 3, 10
+y = np.arange(nx*ny*nz, dtype=float).reshape((nx, ny, nz))
+y += y**1.5
+z = np.arange(nz, dtype=float)
+z = np.broadcast_to(z, y.shape)
+zn = z.copy()
+zn[:, :, [0, -1]] = np.nan
+
+xi_arraylist = [[0.5, 1.5], np.linspace(-1, z.max() + 10, 50)]
+
+# Initial smoke test with small and large xi arrays.
+@pytest.mark.parametrize("xi", xi_arraylist)
+def test_in_range(xi):
+    yi = gsw.pchip_interp(z, y, xi, axis=-1)
+    assert yi.shape == (nx, ny, len(xi))
+
+
+# Try with NaNs.
+@pytest.mark.parametrize("xi", xi_arraylist)
+def test_in_range_nan(xi):
+    yi = gsw.pchip_interp(zn, y, xi, axis=-1)
+    assert yi.shape == (nx, ny, len(xi))

--- a/gsw/utility.py
+++ b/gsw/utility.py
@@ -59,6 +59,6 @@ def pchip_interp(x, y, xi, axis=0):
         xgood = x[ind][igood]
         ygood = y[ind][igood]
 
-        yi[ind][igood] = _gsw_ufuncs.util_pchip_interp(xgood, ygood, xi)
+        yi[ind] = _gsw_ufuncs.util_pchip_interp(xgood, ygood, xi)
 
     return yi


### PR DESCRIPTION
A smoke test has been added for this function.
The function is an additional wrapper around the wrapped ufunc,
the core of which is in C, and it is not used internally.