### PR TITLE
auto deploy to PyPI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -27,12 +27,13 @@ before_install:
   - wget http://bit.ly/miniconda -O miniconda.sh
   - bash miniconda.sh -b -p $HOME/miniconda
   - export PATH="$HOME/miniconda/bin:$PATH"
-  - conda update conda --yes
+  - conda config --set always_yes yes --set changeps1 no --set show_channel_urls true
+  - conda update conda
   - conda config --add channels conda-forge --force
-  - conda create --yes -n TEST python=$TRAVIS_PYTHON_VERSION --file requirements-dev.txt
+  - conda create --name TEST python=$TRAVIS_PYTHON_VERSION --file requirements-dev.txt
   - source activate TEST
   # Install after to ensure it will be downgraded when testing an older version.
-  - conda install --yes --quiet numpy=$NUMPY
+  - conda install numpy=$NUMPY
 
 # Test source distribution.
 install:
@@ -52,3 +53,23 @@ after_success:
       pushd docs && make html && popd ;
       doctr deploy --built-docs=docs/_build/html . ;
     fi
+
+
+doctr:
+  require-master: true
+  sync: false
+
+deploy:
+  skip_cleanup: true
+  provider: pypi
+  user: ocefpaf
+  password:
+    secure: aC6ZixeGhCmxdn3a4skQJHIK9Ffj/p5O1cOjHKXZh1vhHy1t5oEfk1HayWdLq2wRwODx9+Ern6ZsWRv+jiSPiqlHgOL74SHT+ByAX/WaylhhySS5JeTN+jT0vOoB7IZRtAb1QVA7mIifbrLTyHw+jX5pUt+ue1LI5zg+M9ny3E0gFYut6t3C2zbTCACmk3S5+3DXn4BT5aXJhbnF2NKTNvEzhXuL0Vu08N8pClTIQM8ZR2fniqVcM8oCPL/Ecouf7Z6L5ofl8cqdloe9e50/01XCKQs0EUWVko8XlBiKvjOUoUn3oB1rif8hahQpHIrDWNShvBqp1LE/Sxmv2FmtC0C+WAqivMqWyLOxrtZnDpk0/0DGObQ652Ypr2WocC1E2wub7rf1KinNcWmgQGIPzQbUERUYcc2yW1pRfT2oos0QLTzWgTTGlImAeuNo1s9ds7dSYcQCL6z+M0Nq3nZ71gmir22hx/j1N0OQzLBMgxz3m6+pZz6nrNT0YQTFqs/y2A6R8yf46+vySGbzoMKS0OmTmFN6Fr0URoF0oHmztb6y+aVLvHPdtfLV/ryR7DsLKXn7j1FfHoEJNoojCecgL0EZDqWiSX6wLwdTnEkZK56ZTAJGjKPFTPtfxaNLdmc+kweGhIXINp4qacWASIYBm1vldToSC2KiRo+aPKcYRaQ=
+  distributions: sdist bdist_wheel
+  upload_docs: no
+  on:
+    repo: TEOS-10/GSW-Python
+    tags: true
+    python: 3.6
+    all_branches: master
+    condition: '$TEST_TARGET == "default"'


### PR DESCRIPTION
@efiring if this works all we need to do for a new release is to tag it, then Travis-CI and `versioneer` will take care of the rest. (Even the conda packages will be automated b/c the bots listen to PyPI releases.)