### PR TITLE
Bugfix: make distance() work with no pressure argument

### DIFF
--- a/gsw/geostrophy.py
+++ b/gsw/geostrophy.py
@@ -187,7 +187,9 @@ def distance(lon, lat, p=0, axis=-1):
     else:
         one_d = False
 
-    one_d = one_d and p.ndim == 1
+    # Handle scalar default; match_args_return doesn't see it.
+    p = np.atleast_1d(p)
+    one_d = (one_d and p.ndim == 1)
 
     if axis == 0:
         indm = (slice(0, -1), slice(None))

--- a/gsw/tests/test_geostrophy.py
+++ b/gsw/tests/test_geostrophy.py
@@ -26,6 +26,10 @@ def test_1darray():
     value = gsw.distance(np.array(lon), np.array(lat), p=0, axis=-1)
     assert_almost_equal(expected, value)
 
+def test_1darray_default_p():
+    # @match_args_return doesn't see the default p.
+    value = gsw.distance(np.array(lon), np.array(lat))
+    assert_almost_equal(expected, value)
 
 def test_2dlist():
     value = gsw.distance(np.atleast_2d(lon), np.atleast_2d(lat), p=0, axis=1)


### PR DESCRIPTION
This is a bit subtle: we want an immutable default, p=0,
but internally p needs to be an array.  When p is given
explicitly as a scalar argument, the match_args_return
decorator takes care of it, but to allow it to be optional
we need to do the conversion to array in the function
itself.