### PR TITLE
update CIs

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -1,23 +1,23 @@
 environment:
   matrix:
     - TARGET_ARCH: x64
-      CONDA_PY: 3.5
+      CONDA_PY: 3.6
       CONDA_NPY: 1.11
       CONDA_INSTALL_LOCN: C:\\Miniconda35-x64
 
     - TARGET_ARCH: x64
-      CONDA_PY: 3.5
-      CONDA_NPY: 1.14
+      CONDA_PY: 3.6
+      CONDA_NPY: 1.16
       CONDA_INSTALL_LOCN: C:\\Miniconda35-x64
 
     - TARGET_ARCH: x64
-      CONDA_PY: 3.6
+      CONDA_PY: 3.7
       CONDA_NPY: 1.11
       CONDA_INSTALL_LOCN: C:\\Miniconda36-x64
 
     - TARGET_ARCH: x64
-      CONDA_PY: 3.6
-      CONDA_NPY: 1.14
+      CONDA_PY: 3.7
+      CONDA_NPY: 1.16
       CONDA_INSTALL_LOCN: C:\\Miniconda36-x64
 
 platform:
@@ -37,13 +37,14 @@ install:
   - cmd: set "PATH=%CONDA_INSTALL_LOCN%\\Scripts;%CONDA_INSTALL_LOCN%\\Library\\bin;%PATH%"
   - cmd: conda config --set always_yes yes --set changeps1 no --set show_channel_urls true
   - cmd: conda update conda
+  - cmd: conda config --add channels conda-forge --force
   - cmd: call %CONDA_INSTALL_LOCN%\Scripts\activate.bat
 
   - cmd: set PYTHONUNBUFFERED=1
 
   - cmd: conda create --name TEST python=%CONDA_PY% numpy=%CONDA_NPY% pytest pip
+  - cmd: conda info --all
   - cmd: activate TEST
-  - cmd: conda info
 
 # Skip .NET project specific build phase.
 build: off

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,4 @@
-language: python
+language: minimal
 
 sudo: false
 
@@ -9,18 +9,18 @@ env:
 matrix:
   fast_finish: true
   include:
-  - python: 3.5
-    env: TEST_TARGET=default NUMPY=1.11
-  - python: 3.5
-    env: TEST_TARGET=default NUMPY=1.14
-  - python: 3.6
-    env: TEST_TARGET=default NUMPY=1.11
-  - python: 3.6
-    env: TEST_TARGET=default NUMPY=1.14
-  - python: 3.6
-    env: TEST_TARGET=publish NUMPY=1.14
-  - python: 3.6
-    env: TEST_TARGET=deploy NUMPY=1.14
+  - name: py36-np111
+    env: TEST_TARGET=default NUMPY=1.11 PY=3.6
+  - name: py36-np116
+    env: TEST_TARGET=default NUMPY=1.16 PY=3.6
+  - name: py37-np111
+    env: TEST_TARGET=default NUMPY=1.11 PY=3.7
+  - name: py37-np116
+    env: TEST_TARGET=default NUMPY=1.16 PY=3.7
+  - name: publish
+    env: NUMPY=1.16 PY=3.7    
+  - name: deploy
+    env: NUMPY=1.16 PY=3.7
 
 before_install:
   - wget http://bit.ly/miniconda -O miniconda.sh
@@ -29,7 +29,7 @@ before_install:
   - conda config --set always_yes yes --set changeps1 no --set show_channel_urls true
   - conda update conda
   - conda config --add channels conda-forge --force
-  - conda create --name TEST python=$TRAVIS_PYTHON_VERSION --file requirements-dev.txt
+  - conda create --name TEST python=$PY --file requirements-dev.txt
   - source activate TEST
   # Install after to ensure it will be downgraded when testing an older version.
   - conda install numpy=$NUMPY
@@ -40,12 +40,12 @@ install:
   - python setup.py sdist && version=$(python setup.py --version) && pushd dist  && pip install gsw-${version}.tar.gz && popd
 
 script:
-  - if [[ $TEST_TARGET == "default" ]]; then
-      pushd gsw && py.test -s -rxs -v tests && popd ;
+  - if [[ $TRAVIS_JOB_NAME == "default" ]]; then
+      pushd gsw && pytest -s -rxs -v tests && popd ;
     fi
 
 after_success:
-  - if [[ $TEST_TARGET == "publish" ]]; then
+  - if [[ $TRAVIS_JOB_NAME == "publish" ]]; then
       set -e ;
       pushd docs && make html && popd ;
       doctr deploy --built-docs=docs/_build/html . ;
@@ -66,6 +66,5 @@ deploy:
   on:
     repo: TEOS-10/GSW-Python
     tags: true
-    python: 3.6
     all_branches: master
-    condition: '$TEST_TARGET == "deploy"'
+    condition: '$TRAVIS_JOB_NAME == "deploy"'


### PR DESCRIPTION
@efiring this PR updates the CIs to test against latest Python and Numpy and drops Python 3.5 b/c conda-forge stopped building packages for it.