### PR TITLE
Adding references to the DOI record

### DIFF
--- a/.zenodo.json
+++ b/.zenodo.json
@@ -1,0 +1,14 @@
+{
+  "related_identifiers": [
+    {
+      "scheme": "isbn",
+      "identifier": "978-0-646-55621-5",
+      "relation": "references"
+    },
+    {
+      "scheme": "handle",
+      "identifier": "http://hdl.handle.net/11329/286",
+      "relation": "references"
+    }
+  ]
+}


### PR DESCRIPTION
This file informs Zenodo to add TEOS-10 ([Manual](http://www.teos-10.org/pubs/TEOS-10_Manual.pdf) & [Getting started](http://www.teos-10.org/pubs/Getting_Started.pdf)) as references within the DOI record. This is equivalent to the references list in a regular paper.

It will take effect on the next release.

For more information and options: [https://github.com/castelao/inception](https://github.com/castelao/inception).