### PR TITLE
build wheel for Python 3.9

### DIFF
--- a/.github/workflows/actions/entrypoint.sh
+++ b/.github/workflows/actions/entrypoint.sh
@@ -1,6 +1,6 @@
 #!/bin/sh
 
-PYTHONS=("cp36-cp36m" "cp37-cp37m" "cp38-cp38")
+PYTHONS=("cp37-cp37m" "cp38-cp38" "cp39-cp39")
 
 for PYTHON in ${PYTHONS[@]}; do
     /opt/python/${PYTHON}/bin/pip install --upgrade pip wheel setuptools setuptools_scm pep517 twine auditwheel

--- a/.github/workflows/build_linux.yml
+++ b/.github/workflows/build_linux.yml
@@ -19,7 +19,7 @@ jobs:
     - name: copy manylinux wheels
       run: |
         mkdir dist
-        cp wheelhouse/gsw*-manylinux2010_x86_64.whl dist/
+        cp wheelhouse/gsw*.whl dist/
 
     - name: CheckFiles
       run: |

--- a/.github/workflows/build_mac.yml
+++ b/.github/workflows/build_mac.yml
@@ -12,7 +12,7 @@ jobs:
     strategy:
       matrix:
         os: [macos-latest]
-        python-version: [3.6, 3.7, 3.8]
+        python-version: [3.7, 3.8, 3.9]
 
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/build_win.yml
+++ b/.github/workflows/build_win.yml
@@ -12,7 +12,7 @@ jobs:
     strategy:
       matrix:
         os: [windows-latest]
-        python-version: [3.6, 3.7, 3.8]
+        python-version: [3.7, 3.8, 3.9]
 
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/tarball-tests.yml
+++ b/.github/workflows/tarball-tests.yml
@@ -29,6 +29,6 @@ jobs:
       shell: bash -l {0}
       run: |
         source activate TEST
-        python -m build --skip-dependencies --sdist --wheel .
+        python -m build --skip-dependency-check --sdist --wheel .
         check-manifest --verbose
         twine check dist/*


### PR DESCRIPTION
Avoid compilation when installing with pip on Python 3.9. See https://github.com/TEOS-10/GSW-Python/issues/78