### PR TITLE
needs to avoid globing them before the autidwheel

### DIFF
--- a/.github/workflows/actions/entrypoint.sh
+++ b/.github/workflows/actions/entrypoint.sh
@@ -1,11 +1,14 @@
 #!/bin/sh
 
-PYTHONS=("cp37-cp37m" "cp38-cp38" "cp39-cp39")
+# if testing locally try the docker image interactively
+# docker run --net=host -it --rm -v $(pwd):/home/ quay.io/pypa/manylinux2010_x86_64
+
+PYTHONS=("cp38-cp38" "cp39-cp39" "cp310-cp310")
 
 for PYTHON in ${PYTHONS[@]}; do
     /opt/python/${PYTHON}/bin/pip install --upgrade pip wheel setuptools setuptools_scm pep517 twine auditwheel
-    /opt/python/${PYTHON}/bin/pip install numpy==1.18
-    /opt/python/${PYTHON}/bin/python -m pep517.build --source --binary . --out-dir /github/workspace/wheelhouse/
+    /opt/python/${PYTHON}/bin/pip install oldest-supported-numpy
+    /opt/python/${PYTHON}/bin/python -m build --sdist --wheel . --outdir /github/workspace/wheelhouse/
 done
 
 for whl in /github/workspace/wheelhouse/gsw*.whl; do

--- a/.github/workflows/build_linux.yml
+++ b/.github/workflows/build_linux.yml
@@ -19,7 +19,7 @@ jobs:
     - name: copy manylinux wheels
       run: |
         mkdir dist
-        cp wheelhouse/gsw*.whl dist/
+        cp wheelhouse/gsw*manylinux2010_x86_64.whl dist/
 
     - name: CheckFiles
       run: |

--- a/.github/workflows/build_mac.yml
+++ b/.github/workflows/build_mac.yml
@@ -12,7 +12,7 @@ jobs:
     strategy:
       matrix:
         os: [macos-latest]
-        python-version: [3.7, 3.8, 3.9]
+        python-version: ["3.8", "3.9", "3.10"]
 
     steps:
     - uses: actions/checkout@v2
@@ -29,7 +29,7 @@ jobs:
     - name: Install build tools
       run: |
         python -m pip install --upgrade pip wheel setuptools setuptools_scm pep517 twine
-        python -m pip install numpy==1.18
+        python -m pip install oldest-supported-numpy
       shell: bash
 
     - name: Build binary wheel

--- a/.github/workflows/build_win.yml
+++ b/.github/workflows/build_win.yml
@@ -12,7 +12,7 @@ jobs:
     strategy:
       matrix:
         os: [windows-latest]
-        python-version: [3.7, 3.8, 3.9]
+        python-version: ["3.8", "3.9", "3.10"]
 
     steps:
     - uses: actions/checkout@v2
@@ -29,7 +29,7 @@ jobs:
     - name: Install build tools
       run: |
         python -m pip install --upgrade pip wheel setuptools setuptools_scm pep517 twine
-        python -m pip install numpy==1.18
+        python -m pip install oldest-supported-numpy
       shell: bash
 
     - name: Build binary wheel


### PR DESCRIPTION
@efiring minor hiccup and this is ready to go.

BTW, I got my laptop and cellphone stolen recently and I'm locked out of PyPI. See https://github.com/pypa/pypi-support/issues/1201

Can you download the artifacts generated here and upload them to PyPI?

macOS: https://github.com/TEOS-10/GSW-Python/actions/runs/1141259864
Windows: https://github.com/TEOS-10/GSW-Python/actions/runs/1141259865

The linux one is attached here. The artifact should've been uploaded automatic but my credentials to PyPI are expired too and I cannot renew them at the moment :-/

[linux.zip](https://github.com/TEOS-10/GSW-Python/files/7003674/linux.zip)


PS0: if you place them all in a "dist" folder you can run `twine upload dist/* --verbose` once.
PS1: @DocOtak maybe we should add you too the PyPI maintainers list. We went from 2 to 1 until PyPA folks answer my issue :worried:  