### PR TITLE
Fix the latitude range for the functions that use gsw_saar

### DIFF
--- a/gsw/_wrapped_ufuncs.py
+++ b/gsw/_wrapped_ufuncs.py
@@ -780,7 +780,7 @@ def deltaSA_atlas(p, lon, lat):
     lon : array-like
         Longitude, -360 to 360 degrees
     lat : array-like
-        Latitude, -90 to 90 degrees
+        Latitude, -86 to 90 degrees
 
     Returns
     -------

--- a/gsw/_wrapped_ufuncs.py
+++ b/gsw/_wrapped_ufuncs.py
@@ -807,7 +807,7 @@ def deltaSA_from_SP(SP, p, lon, lat):
     lon : array-like
         Longitude, -360 to 360 degrees
     lat : array-like
-        Latitude, -90 to 90 degrees
+        Latitude, -86 to 90 degrees
 
     Returns
     -------
@@ -1306,7 +1306,7 @@ def Fdelta(p, lon, lat):
     lon : array-like
         Longitude, -360 to 360 degrees
     lat : array-like
-        Latitude, -90 to 90 degrees
+        Latitude, -86 to 90 degrees
 
     Returns
     -------
@@ -3233,7 +3233,7 @@ def SA_from_SP(SP, p, lon, lat):
     lon : array-like
         Longitude, -360 to 360 degrees
     lat : array-like
-        Latitude, -90 to 90 degrees
+        Latitude, -86 to 90 degrees
 
     Returns
     -------
@@ -3285,7 +3285,7 @@ def SA_from_Sstar(Sstar, p, lon, lat):
     lon : array-like
         Longitude, -360 to 360 degrees
     lat : array-like
-        Latitude, -90 to 90 degrees
+        Latitude, -86 to 90 degrees
 
     Returns
     -------
@@ -3310,7 +3310,7 @@ def SAAR(p, lon, lat):
     lon : array-like
         Longitude, -360 to 360 degrees
     lat : array-like
-        Latitude, -90 to 90 degrees
+        Latitude, -86 to 90 degrees
 
     Returns
     -------
@@ -3617,7 +3617,7 @@ def SP_from_SA(SA, p, lon, lat):
     lon : array-like
         Longitude, -360 to 360 degrees
     lat : array-like
-        Latitude, -90 to 90 degrees
+        Latitude, -86 to 90 degrees
 
     Returns
     -------
@@ -3706,7 +3706,7 @@ def SP_from_Sstar(Sstar, p, lon, lat):
     lon : array-like
         Longitude, -360 to 360 degrees
     lat : array-like
-        Latitude, -90 to 90 degrees
+        Latitude, -86 to 90 degrees
 
     Returns
     -------
@@ -4137,7 +4137,7 @@ def Sstar_from_SA(SA, p, lon, lat):
     lon : array-like
         Longitude, -360 to 360 degrees
     lat : array-like
-        Latitude, -90 to 90 degrees
+        Latitude, -86 to 90 degrees
 
     Returns
     -------
@@ -4164,7 +4164,7 @@ def Sstar_from_SP(SP, p, lon, lat):
     lon : array-like
         Longitude, -360 to 360 degrees
     lat : array-like
-        Latitude, -90 to 90 degrees
+        Latitude, -86 to 90 degrees
 
     Returns
     -------


### PR DESCRIPTION
I have been using [Hypothesis](https://hypothesis.readthedocs.io/en/latest/) to test scientific Python packages with Property Based Tests and found a discrepancy between the documentation and the underlying code.

The documentation says that latitude values in the range `[-90, 90]` are valid, however if the latitude value is less than `-86` an error is thrown and `NaN` is returned. The cause of this can be seen in the C implementation of the `gsw_saar` function (see [here](https://github.com/TEOS-10/GSW-Python/blob/69a903b46dcff9b736461f1398114b9c5950ffc4/src/c_gsw/gsw_saar.c#L62)) as it returns an error if `(lat  <  -86.0  ||  lat  >  90.0)`. Not all functions with latitude parameters are affected as they don't all call `gsw_saar`. 

The following functions are affected:

- SA_from_SP
- SA_from_Sstar
- SP_from_SA
- SP_from_Sstar
- Sstar_from_SA
- Sstar_from_SP
- Fdelta
- deltaSA_from_SP
- SAAR
- deltaSA_atlas

**Example**

```
sa_from_sp(0.0, 0.0, 0.0, -86.00000000000001)
# Returns NaN
```

**Solution**

I have updated the documentation for the latitude parameter to be in the range `[-86, 90]` instead of `[-90, 90]` for the affected functions. I imagine this is a problem with the documentation rather than the implementation of `gsw_saar`. Please feel free to accept the PR if appropriate, feedback would be appreciated otherwise.

