### PR TITLE
Wrap longitude, 0-360, where it is used directly.

### DIFF
--- a/gsw/tests/test_check_functions.py
+++ b/gsw/tests/test_check_functions.py
@@ -45,13 +45,20 @@ mfuncs = [mf for mf in mfuncs if mf.name in d and mf.name not in blacklist]
 mfuncnames = [mf.name for mf in mfuncs]
 
 
-@pytest.fixture(scope='session', params=mfuncs)
-def cfcf(request):
-    return cv, cf, request.param
+@pytest.fixture(params=[-360, 0, 360])
+def lonshift(request):
+    return request.param
 
 
-def test_check_function(cfcf):
-    cv, cf, mfunc = cfcf
+@pytest.fixture(params=mfuncs, ids=mfuncnames)
+def setup(request, lonshift):
+    cvshift = Bunch(**cv)
+    cvshift.long_chck_cast = cv.long_chck_cast + lonshift
+    return cvshift, cf, request.param
+
+
+def test_check_function(setup):
+    cv, cf, mfunc = setup
     mfunc.run(locals())
     if mfunc.exception is not None or not mfunc.passed:
         print('\n', mfunc.name)

--- a/src/c_gsw/gsw_oceanographic_toolbox.c
+++ b/src/c_gsw/gsw_oceanographic_toolbox.c
@@ -8992,6 +8992,10 @@ gsw_sa_from_sp_baltic(double sp, double lon, double lat)
         GSW_BALTIC_DATA;
         double  xx_left, xx_right, return_value;
 
+        lon = fmod(lon, 360.0);
+        if (lon  <  0.0)
+            lon += 360.0;
+
         if (xb_left[1] < lon  && lon < xb_right[0]  && yb_left[0] < lat  &&
             lat < yb_left[2]) {
 
@@ -9534,6 +9538,10 @@ gsw_sp_from_sa_baltic(double sa, double lon, double lat)
         GSW_TEOS10_CONSTANTS;
         GSW_BALTIC_DATA;
         double  xx_left, xx_right, return_value;
+
+        lon = fmod(lon, 360.0);
+        if (lon  <  0.0)
+            lon += 360.0;
 
         if (xb_left[1] < lon  && lon < xb_right[0]  && yb_left[0] < lat  &&
             lat < yb_left[2]) {

--- a/src/c_gsw/gsw_saar.c
+++ b/src/c_gsw/gsw_saar.c
@@ -62,6 +62,7 @@ gsw_saar(double p, double lon, double lat)
         if (lat  <  -86.0  ||  lat  >  90.0)
             return (return_value);
 
+        lon = fmod(lon, 360.0);
         if (lon  <  0.0)
             lon += 360.0;
 
@@ -180,6 +181,7 @@ gsw_deltasa_atlas(double p, double lon, double lat)
         if (lat < -86.0  ||  lat  >  90.0)
             return (return_value);
 
+        lon = fmod(lon, 360.0);
         if (lon < 0.0)
             lon += 360.0;
 


### PR DESCRIPTION
Closes #85.

For functions that take a longitude argument but merely pass it to
another function, we leave the argument as-is.