### PR TITLE
use np.expand_dims instead of np.newaxis

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -33,13 +33,18 @@ jobs:
       run: |
         micromamba create --name TEST python=${{ matrix.python-version }} python-build numpy=${{ matrix.numpy-version }} --file requirements-dev.txt --channel conda-forge
         micromamba activate TEST
-        pip install -e . --no-deps --force-reinstall
+        python -m pip install -e . --no-deps --no-build-isolation --force-reinstall
+
+    - name: Debug
+      shell: bash -l {0}
+      run: |
+        micromamba activate TEST
         micromamba info --all
         micromamba list
+        python -c "import numpy; print(f'Running numpy {numpy.__version__}')"
 
     - name: Tests
       shell: bash -l {0}
       run: |
         micromamba activate TEST
-        python -c "import numpy; print(f'Running numpy {numpy.__version__}')"
         pytest -s -rxs -v gsw/tests

--- a/gsw/geostrophy.py
+++ b/gsw/geostrophy.py
@@ -184,8 +184,9 @@ def distance(lon, lat, p=0, axis=-1):
                           % (lon.shape, axis))
     if lon.ndim == 1:
         one_d = True
-        lon = np.expand_dims(lon, (0,))
-        lat = np.expand_dims(lat, (0,))
+        # xarray requires expand_dims() rather than [newaxis, :]
+        lon = np.expand_dims(lon, 0)
+        lat = np.expand_dims(lat, 0)
         axis = -1
     else:
         one_d = False

--- a/gsw/geostrophy.py
+++ b/gsw/geostrophy.py
@@ -184,8 +184,8 @@ def distance(lon, lat, p=0, axis=-1):
                           % (lon.shape, axis))
     if lon.ndim == 1:
         one_d = True
-        lon = lon[np.newaxis, :]
-        lat = lat[np.newaxis, :]
+        lon = np.expand_dims(lon, (0,))
+        lat = np.expand_dims(lat, (0,))
         axis = -1
     else:
         one_d = False

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,3 +1,3 @@
 [build-system]
-requires = ["pip >9.0.1", "setuptools>=42", "wheel", "setuptools_scm[toml]>=3.4", "oldest-supported-numpy", "build"]
+requires = ["pip>9.0.1", "setuptools>=42", "wheel", "setuptools_scm[toml]>=3.4", "oldest-supported-numpy", "build"]
 build-backend = "setuptools.build_meta"


### PR DESCRIPTION
The use of `[np.newaxis, lon]` is the distance function in geostrophy.py was not compatible with xarray (see exemple below). This PR fixes this issue.

## Exemple
```python
import xarray as xr
import gsw
da = xr.DataArray([0,1])
gsw.distance(da, da)
```
outputs
```python
---------------------------------------------------------------------------
IndexError                                Traceback (most recent call last)
<ipython-input-59-24e6827f537c> in <module>
----> 1 gsw.distance(da, da)

~/.cache/pypoetry/virtualenvs/gsw-xarray-NsrEXKiZ-py3.8/lib/python3.8/site-packages/gsw/_utilities.py in wrapper(*args, **kw)
     60             kw['p'] = newargs.pop()
     61 
---> 62         ret = f(*newargs, **kw)
     63 
     64         if isinstance(ret, tuple):

~/.cache/pypoetry/virtualenvs/gsw-xarray-NsrEXKiZ-py3.8/lib/python3.8/site-packages/gsw/geostrophy.py in distance(lon, lat, p, axis)
    185     if lon.ndim == 1:
    186         one_d = True
--> 187         lon = lon[np.newaxis, :]
    188         lat = lat[np.newaxis, :]
    189         axis = -1

~/.cache/pypoetry/virtualenvs/gsw-xarray-NsrEXKiZ-py3.8/lib/python3.8/site-packages/xarray/core/dataarray.py in __getitem__(self, key)
    739         else:
    740             # xarray-style array indexing
--> 741             return self.isel(indexers=self._item_key_to_dict(key))
    742 
    743     def __setitem__(self, key: Any, value: Any) -> None:

~/.cache/pypoetry/virtualenvs/gsw-xarray-NsrEXKiZ-py3.8/lib/python3.8/site-packages/xarray/core/dataarray.py in _item_key_to_dict(self, key)
    703         if utils.is_dict_like(key):
    704             return key
--> 705         key = indexing.expanded_indexer(key, self.ndim)
    706         return dict(zip(self.dims, key))
    707 

~/.cache/pypoetry/virtualenvs/gsw-xarray-NsrEXKiZ-py3.8/lib/python3.8/site-packages/xarray/core/indexing.py in expanded_indexer(key, ndim)
     48             new_key.append(k)
     49     if len(new_key) > ndim:
---> 50         raise IndexError("too many indices")
     51     new_key.extend((ndim - len(new_key)) * [slice(None)])
     52     return tuple(new_key)

IndexError: too many indices
```
