### PR TITLE
Add consts to PyUFuncGenericFunction declarations

### DIFF
--- a/src/_ufuncs.c
+++ b/src/_ufuncs.c
@@ -26,8 +26,8 @@ This is python 3-only (for simplicity) to begin with.
 
 
 /* 1 in, 1 out */
-static void loop1d_d_d(char **args, npy_intp *dimensions,
-                          npy_intp* steps, void* data)
+static void loop1d_d_d(char **args, const npy_intp *dimensions,
+                          const npy_intp* steps, void* data)
 {
     npy_intp i;
     npy_intp n = dimensions[0];
@@ -59,8 +59,8 @@ static char types_d_d[] = {
 };
 
 /* 2 in, 1 out */
-static void loop1d_dd_d(char **args, npy_intp *dimensions,
-                          npy_intp* steps, void* data)
+static void loop1d_dd_d(char **args, const npy_intp *dimensions,
+                          const npy_intp* steps, void* data)
 {
     npy_intp i;
     npy_intp n = dimensions[0];
@@ -95,8 +95,8 @@ static char types_dd_d[] = {
 };
 
 /* 3 in, 1 out */
-static void loop1d_ddd_d(char **args, npy_intp *dimensions,
-                          npy_intp* steps, void* data)
+static void loop1d_ddd_d(char **args, const npy_intp *dimensions,
+                          const npy_intp* steps, void* data)
 {
     npy_intp i;
     npy_intp n = dimensions[0];
@@ -134,8 +134,8 @@ static char types_ddd_d[] = {
 };
 
 /* 4 in, 1 out */
-static void loop1d_dddd_d(char **args, npy_intp *dimensions,
-                          npy_intp* steps, void* data)
+static void loop1d_dddd_d(char **args, const npy_intp *dimensions,
+                          const npy_intp* steps, void* data)
 {
     npy_intp i;
     npy_intp n = dimensions[0];
@@ -176,8 +176,8 @@ static char types_dddd_d[] = {
 };
 
 /* 5 in, 1 out */
-static void loop1d_ddddd_d(char **args, npy_intp *dimensions,
-                          npy_intp* steps, void* data)
+static void loop1d_ddddd_d(char **args, const npy_intp *dimensions,
+                          const npy_intp* steps, void* data)
 {
     npy_intp i;
     npy_intp n = dimensions[0];
@@ -221,8 +221,8 @@ static char types_ddddd_d[] = {
 };
 
 /* 2 in, 2 out */
-static void loop1d_dd_dd(char **args, npy_intp *dimensions,
-                          npy_intp* steps, void* data)
+static void loop1d_dd_dd(char **args, const npy_intp *dimensions,
+                          const npy_intp* steps, void* data)
 {
     npy_intp i;
     npy_intp n = dimensions[0];
@@ -261,8 +261,8 @@ static char types_dd_dd[] = {
 };
 
 /* 3 in, 2 out */
-static void loop1d_ddd_dd(char **args, npy_intp *dimensions,
-                          npy_intp* steps, void* data)
+static void loop1d_ddd_dd(char **args, const npy_intp *dimensions,
+                          const npy_intp* steps, void* data)
 {
     npy_intp i;
     npy_intp n = dimensions[0];
@@ -304,8 +304,8 @@ static char types_ddd_dd[] = {
 };
 
 /* 3 in, 3 out */
-static void loop1d_ddd_ddd(char **args, npy_intp *dimensions,
-                          npy_intp* steps, void* data)
+static void loop1d_ddd_ddd(char **args, const npy_intp *dimensions,
+                          const npy_intp* steps, void* data)
 {
     npy_intp i;
     npy_intp n = dimensions[0];
@@ -351,8 +351,8 @@ static char types_ddd_ddd[] = {
 };
 
 /* 6 in, 2 out */
-static void loop1d_dddddd_dd(char **args, npy_intp *dimensions,
-                          npy_intp* steps, void* data)
+static void loop1d_dddddd_dd(char **args, const npy_intp *dimensions,
+                          const npy_intp* steps, void* data)
 {
     npy_intp i;
     npy_intp n = dimensions[0];
@@ -403,8 +403,8 @@ static char types_dddddd_dd[] = {
 };
 
 /* 2 in, 3 out */
-static void loop1d_dd_ddd(char **args, npy_intp *dimensions,
-                          npy_intp* steps, void* data)
+static void loop1d_dd_ddd(char **args, const npy_intp *dimensions,
+                          const npy_intp* steps, void* data)
 {
     npy_intp i;
     npy_intp n = dimensions[0];
@@ -447,8 +447,8 @@ static char types_dd_ddd[] = {
 };
 
 /* 4 in, 3 out */
-static void loop1d_dddd_ddd(char **args, npy_intp *dimensions,
-                          npy_intp* steps, void* data)
+static void loop1d_dddd_ddd(char **args, const npy_intp *dimensions,
+                          const npy_intp* steps, void* data)
 {
     npy_intp i;
     npy_intp n = dimensions[0];
@@ -497,8 +497,8 @@ static char types_dddd_ddd[] = {
 };
 
 /* 5 in, 3 out */
-static void loop1d_ddddd_ddd(char **args, npy_intp *dimensions,
-                          npy_intp* steps, void* data)
+static void loop1d_ddddd_ddd(char **args, const npy_intp *dimensions,
+                          const npy_intp* steps, void* data)
 {
     npy_intp i;
     npy_intp n = dimensions[0];
@@ -550,8 +550,8 @@ static char types_ddddd_ddd[] = {
 };
 
 /* 3 in, 5 out */
-static void loop1d_ddd_ddddd(char **args, npy_intp *dimensions,
-                          npy_intp* steps, void* data)
+static void loop1d_ddd_ddddd(char **args, const npy_intp *dimensions,
+                          const npy_intp* steps, void* data)
 {
     npy_intp i;
     npy_intp n = dimensions[0];

--- a/src/_ufuncs.c
+++ b/src/_ufuncs.c
@@ -26,8 +26,8 @@ This is python 3-only (for simplicity) to begin with.
 
 
 /* 1 in, 1 out */
-static void loop1d_d_d(char **args, const npy_intp *dimensions,
-                          const npy_intp* steps, void* data)
+static void loop1d_d_d(char **args, npy_intp const *dimensions,
+                          npy_intp const* steps, void* data)
 {
     npy_intp i;
     npy_intp n = dimensions[0];
@@ -59,8 +59,8 @@ static char types_d_d[] = {
 };
 
 /* 2 in, 1 out */
-static void loop1d_dd_d(char **args, const npy_intp *dimensions,
-                          const npy_intp* steps, void* data)
+static void loop1d_dd_d(char **args, npy_intp const *dimensions,
+                          npy_intp const* steps, void* data)
 {
     npy_intp i;
     npy_intp n = dimensions[0];
@@ -95,8 +95,8 @@ static char types_dd_d[] = {
 };
 
 /* 3 in, 1 out */
-static void loop1d_ddd_d(char **args, const npy_intp *dimensions,
-                          const npy_intp* steps, void* data)
+static void loop1d_ddd_d(char **args, npy_intp const *dimensions,
+                          npy_intp const* steps, void* data)
 {
     npy_intp i;
     npy_intp n = dimensions[0];
@@ -134,8 +134,8 @@ static char types_ddd_d[] = {
 };
 
 /* 4 in, 1 out */
-static void loop1d_dddd_d(char **args, const npy_intp *dimensions,
-                          const npy_intp* steps, void* data)
+static void loop1d_dddd_d(char **args, npy_intp const *dimensions,
+                          npy_intp const* steps, void* data)
 {
     npy_intp i;
     npy_intp n = dimensions[0];
@@ -176,8 +176,8 @@ static char types_dddd_d[] = {
 };
 
 /* 5 in, 1 out */
-static void loop1d_ddddd_d(char **args, const npy_intp *dimensions,
-                          const npy_intp* steps, void* data)
+static void loop1d_ddddd_d(char **args, npy_intp const *dimensions,
+                          npy_intp const* steps, void* data)
 {
     npy_intp i;
     npy_intp n = dimensions[0];
@@ -221,8 +221,8 @@ static char types_ddddd_d[] = {
 };
 
 /* 2 in, 2 out */
-static void loop1d_dd_dd(char **args, const npy_intp *dimensions,
-                          const npy_intp* steps, void* data)
+static void loop1d_dd_dd(char **args, npy_intp const *dimensions,
+                          npy_intp const* steps, void* data)
 {
     npy_intp i;
     npy_intp n = dimensions[0];
@@ -261,8 +261,8 @@ static char types_dd_dd[] = {
 };
 
 /* 3 in, 2 out */
-static void loop1d_ddd_dd(char **args, const npy_intp *dimensions,
-                          const npy_intp* steps, void* data)
+static void loop1d_ddd_dd(char **args, npy_intp const *dimensions,
+                          npy_intp const* steps, void* data)
 {
     npy_intp i;
     npy_intp n = dimensions[0];
@@ -304,8 +304,8 @@ static char types_ddd_dd[] = {
 };
 
 /* 3 in, 3 out */
-static void loop1d_ddd_ddd(char **args, const npy_intp *dimensions,
-                          const npy_intp* steps, void* data)
+static void loop1d_ddd_ddd(char **args, npy_intp const *dimensions,
+                          npy_intp const* steps, void* data)
 {
     npy_intp i;
     npy_intp n = dimensions[0];
@@ -351,8 +351,8 @@ static char types_ddd_ddd[] = {
 };
 
 /* 6 in, 2 out */
-static void loop1d_dddddd_dd(char **args, const npy_intp *dimensions,
-                          const npy_intp* steps, void* data)
+static void loop1d_dddddd_dd(char **args, npy_intp const *dimensions,
+                          npy_intp const* steps, void* data)
 {
     npy_intp i;
     npy_intp n = dimensions[0];
@@ -403,8 +403,8 @@ static char types_dddddd_dd[] = {
 };
 
 /* 2 in, 3 out */
-static void loop1d_dd_ddd(char **args, const npy_intp *dimensions,
-                          const npy_intp* steps, void* data)
+static void loop1d_dd_ddd(char **args, npy_intp const *dimensions,
+                          npy_intp const* steps, void* data)
 {
     npy_intp i;
     npy_intp n = dimensions[0];
@@ -447,8 +447,8 @@ static char types_dd_ddd[] = {
 };
 
 /* 4 in, 3 out */
-static void loop1d_dddd_ddd(char **args, const npy_intp *dimensions,
-                          const npy_intp* steps, void* data)
+static void loop1d_dddd_ddd(char **args, npy_intp const *dimensions,
+                          npy_intp const* steps, void* data)
 {
     npy_intp i;
     npy_intp n = dimensions[0];
@@ -497,8 +497,8 @@ static char types_dddd_ddd[] = {
 };
 
 /* 5 in, 3 out */
-static void loop1d_ddddd_ddd(char **args, const npy_intp *dimensions,
-                          const npy_intp* steps, void* data)
+static void loop1d_ddddd_ddd(char **args, npy_intp const *dimensions,
+                          npy_intp const* steps, void* data)
 {
     npy_intp i;
     npy_intp n = dimensions[0];
@@ -550,8 +550,8 @@ static char types_ddddd_ddd[] = {
 };
 
 /* 3 in, 5 out */
-static void loop1d_ddd_ddddd(char **args, const npy_intp *dimensions,
-                          const npy_intp* steps, void* data)
+static void loop1d_ddd_ddddd(char **args, npy_intp const *dimensions,
+                          npy_intp const* steps, void* data)
 {
     npy_intp i;
     npy_intp n = dimensions[0];


### PR DESCRIPTION
`PyUFuncGenericFunction` has type `void (*)(char **, const npy_intp *, const npy_intp *, void *)`, so `dimensions` and `steps` should be const. Otherwise compiling with `-Wincompatible-function-pointer-types` will fail:
```
src/_ufuncs.c:54:46: error: incompatible function pointer types initializing 'PyUFuncGenericFunction' (aka 'void (*)(char **, const long *, const long *, void *)') with an expression of type 'void (*)(char **, npy_intp *, npy_intp *, void *)' (aka 'void (*)(char **, long *, long *, void *)') [-Wincompatible-function-pointer-types]
static PyUFuncGenericFunction funcs_d_d[] = {&loop1d_d_d};
```

https://app.circleci.com/pipelines/github/hoodmane/pyodide/3783/workflows/3c5fdd0d-baf9-41b7-8dc8-56511ba2fdc0/jobs/45949