### PR TITLE
test delvewheel

### DIFF
--- a/.github/workflows/cibuildwheel.yml
+++ b/.github/workflows/cibuildwheel.yml
@@ -43,6 +43,8 @@ jobs:
         CIBW_MANYLINUX_X86_64_IMAGE: manylinux2014
         CIBW_TEST_SKIP: "*_arm64"
         CIBW_TEST_REQUIRES: pytest
+        CIBW_BEFORE_BUILD_WINDOWS: "pip install delvewheel"
+        CIBW_REPAIR_WHEEL_COMMAND_WINDOWS: "delvewheel repair -w {dest_dir} {wheel}"
         CIBW_TEST_COMMAND: >
           python -c "import gsw; print(f'gsw v{gsw.__version__}')" &&
           python -m pytest --pyargs gsw


### PR DESCRIPTION
This is similar to auditwheel (Linux) and delocate (macOS) but for Windows, in theory we don't need but it doesn't hurt to run it.