### PR TITLE
Add name setup.py

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -7,7 +7,7 @@ repos:
     - id: check-added-large-files
 
 - repo: https://github.com/codespell-project/codespell
-  rev: v2.2.1
+  rev: v2.2.2
   hooks:
     - id: codespell
       exclude: >

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,6 @@
-'''
+"""
 Minimal setup.py for building gswc.
-'''
+"""
 
 
 import os
@@ -16,16 +16,16 @@ rootpath = os.path.abspath(os.path.dirname(__file__))
 
 
 def read(*parts):
-    return open(os.path.join(rootpath, *parts), 'r').read()
+    return open(os.path.join(rootpath, *parts), "r").read()
 
 
 class build_ext(_build_ext):
     # Extension builder from pandas without the cython stuff
     def build_extensions(self):
-        numpy_incl = pkg_resources.resource_filename('numpy', 'core/include')
+        numpy_incl = pkg_resources.resource_filename("numpy", "core/include")
 
         for ext in self.extensions:
-            if hasattr(ext, 'include_dirs') and not numpy_incl in ext.include_dirs:
+            if hasattr(ext, "include_dirs") and not numpy_incl in ext.include_dirs:
                 ext.include_dirs.append(numpy_incl)
         _build_ext.build_extensions(self)
 
@@ -33,26 +33,33 @@ class build_ext(_build_ext):
 # MSVC can't handle C complex, and distutils doesn't seem to be able to
 # let us force C++ compilation of .c files, so we use the following hack for
 # Windows.
-if sys.platform == 'win32':
-    cext = 'cpp'
-    shutil.copy('src/c_gsw/gsw_oceanographic_toolbox.c',
-                'src/c_gsw/gsw_oceanographic_toolbox.cpp')
-    shutil.copy('src/c_gsw/gsw_saar.c', 'src/c_gsw/gsw_saar.cpp')
+if sys.platform == "win32":
+    cext = "cpp"
+    shutil.copy(
+        "src/c_gsw/gsw_oceanographic_toolbox.c",
+        "src/c_gsw/gsw_oceanographic_toolbox.cpp",
+    )
+    shutil.copy("src/c_gsw/gsw_saar.c", "src/c_gsw/gsw_saar.cpp")
 else:
-    cext = 'c'
+    cext = "c"
 
-ufunc_src_list = ['src/_ufuncs.c',
-                  'src/c_gsw/gsw_oceanographic_toolbox.' + cext,
-                  'src/c_gsw/gsw_saar.' + cext]
+ufunc_src_list = [
+    "src/_ufuncs.c",
+    "src/c_gsw/gsw_oceanographic_toolbox." + cext,
+    "src/c_gsw/gsw_saar." + cext,
+]
 
 config = {
+    # The package metadata is specified in setup.cfg but GitHub's downstream dependency graph
+    # does not work unless we put the name this here too.
+    "name": "gsw",
     "use_scm_version": {
         "write_to": "gsw/_version.py",
         "write_to_template": '__version__ = "{version}"',
         "tag_regex": r"^(?P<prefix>v)?(?P<version>[^\+]+)(?P<suffix>.*)?$",
     },
-    "ext_modules": [Extension('gsw._gsw_ufuncs', ufunc_src_list)],
-    "include_dirs": [os.path.join(rootpath, 'src', 'c_gsw')],
+    "ext_modules": [Extension("gsw._gsw_ufuncs", ufunc_src_list)],
+    "include_dirs": [os.path.join(rootpath, "src", "c_gsw")],
     "cmdclass": {"build_ext": build_ext},
 }
 


### PR DESCRIPTION
GitHub dependency graph only works if the package name is listed in a setup.py. This is helpful to access what projects and packages are using this library downstream. The change is mostly harmless to the package and we can drop it when GH adopts a more modern way to parse Python package metadata.