### PR TITLE
Remove used dependency

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,5 +1,4 @@
 check-manifest
-doctr
 numpydoc
 pytest
 setuptools_scm


### PR DESCRIPTION
We are no longer using doctr to build and publish the docs.