### PR TITLE
Update from GSW-C and add declspec for dll export

### DIFF
--- a/gsw/tests/test_dll_export.py
+++ b/gsw/tests/test_dll_export.py
@@ -1,0 +1,13 @@
+import ctypes
+
+import gsw
+
+
+def test_ctypes_access():
+    dllname = gsw._gsw_ufuncs.__file__
+    gswlib = ctypes.cdll.LoadLibrary(dllname)
+    rho_gsw_ctypes = gswlib.gsw_rho  # In-situ density.
+    rho_gsw_ctypes.argtypes = [ctypes.c_double] * 3
+    rho_gsw_ctypes.restype = ctypes.c_double
+    stp = (35.0, 10.0, 0.0)
+    assert rho_gsw_ctypes(*stp) == gsw.rho(*stp)

--- a/src/c_gsw/gsw_oceanographic_toolbox.c
+++ b/src/c_gsw/gsw_oceanographic_toolbox.c
@@ -180,6 +180,39 @@ gsw_add_mean(double *data_in, double *data_out)
 }
 /*
 !==========================================================================
+function gsw_infunnel(sa,ct,p)
+!==========================================================================
+
+! "oceanographic funnel" check for the 75-term equation
+!
+! sa     : Absolute Salinity                                 [g/kg]
+! ct     : Conservative Temperature                          [deg C]
+! p      : sea pressure                                      [dbar]
+!
+! gsw_infunnel : 0, if SA, CT and p are outside the "funnel"
+!                1, if SA, CT and p are inside the "funnel"
+!
+!  Note. The term "funnel" (McDougall et al., 2003) describes the range of
+!    SA, CT and p over which the error in the fit of the computationally
+!    efficient 75-term expression for specific volume in terms of SA, CT
+!    and p was calculated (Roquet et al., 2015).
+*/
+int
+gsw_infunnel(double sa, double ct, double p)
+{
+    return !(p > 8000 ||
+        sa < 0 ||
+        sa > 42 ||
+        (p < 500 && ct < gsw_ct_freezing(sa, p, 0)) ||
+        (p >= 500 && p < 6500 && sa < p * 5e-3 - 2.5) ||
+        (p >= 500 && p < 6500 && ct > (31.66666666666667 - p * 3.333333333333334e-3)) ||
+        (p >= 500 && ct < gsw_ct_freezing(sa, 500, 0)) ||
+        (p >= 6500 && sa < 30) ||
+        (p >= 6500 && ct > 10.0)
+    );
+}
+/*
+!==========================================================================
 function gsw_adiabatic_lapse_rate_from_ct(sa,ct,p)
 !==========================================================================
 
@@ -215,7 +248,7 @@ elemental function gsw_adiabatic_lapse_rate_ice (t, p)
 !         ( i.e. absolute pressure - 10.1325 dbar )
 !
 !    Note.  The output is in unit of degrees Celsius per Pa,
-!      (or equivilently K/Pa) not in units of K/dbar.
+!      (or equivalently K/Pa) not in units of K/dbar.
 !--------------------------------------------------------------------------
 */
 double
@@ -435,7 +468,7 @@ function gsw_c_from_sp(sp,t,p)
 
 !  Calculates conductivity, C, from (SP,t,p) using PSS-78 in the range
 !  2 < SP < 42.  If the input Practical Salinity is less than 2 then a
-!  modified form of the Hill et al. (1986) fomula is used for Practical
+!  modified form of the Hill et al. (1986) formula is used for Practical
 !  Salinity.  The modification of the Hill et al. (1986) expression is to
 !  ensure that it is exactly consistent with PSS-78 at SP = 2.
 !
@@ -2781,12 +2814,12 @@ elemental subroutine gsw_frazil_properties (sa_bulk, h_bulk, p, &
 !  throughout the code).
 !
 !  When the mass fraction w_Ih_final is calculated as being a positive
-!  value, the seawater-ice mixture is at thermodynamic equlibrium.
+!  value, the seawater-ice mixture is at thermodynamic equilibrium.
 !
 !  This code returns w_Ih_final = 0 when the input bulk enthalpy, h_bulk,
 !  is sufficiently large (i.e. sufficiently "warm") so that there is no ice
 !  present in the final state.  In this case the final state consists of
-!  only seawater rather than being an equlibrium mixture of seawater and
+!  only seawater rather than being an equilibrium mixture of seawater and
 !  ice which occurs when w_Ih_final is positive.  Note that when
 !  w_Ih_final = 0, the final seawater is not at the freezing temperature.
 !
@@ -2978,12 +3011,12 @@ elemental subroutine gsw_frazil_properties_potential (sa_bulk, h_pot_bulk,&
 !  is assumed to be zero throughout the code).
 !
 !  When the mass fraction w_Ih_final is calculated as being a positive
-!  value, the seawater-ice mixture is at thermodynamic equlibrium.
+!  value, the seawater-ice mixture is at thermodynamic equilibrium.
 !
 !  This code returns w_Ih_final = 0 when the input bulk enthalpy, h_bulk,
 !  is sufficiently large (i.e. sufficiently "warm") so that there is no ice
 !  present in the final state.  In this case the final state consists of
-!  only seawater rather than being an equlibrium mixture of seawater and
+!  only seawater rather than being an equilibrium mixture of seawater and
 !  ice which occurs when w_Ih_final is positive.  Note that when
 !  w_Ih_final = 0, the final seawater is not at the freezing temperature.
 !
@@ -3249,12 +3282,12 @@ elemental subroutine gsw_frazil_properties_potential_poly (sa_bulk, &
 !  is assumed to be zero throughout the code).
 !
 !  When the mass fraction w_Ih_final is calculated as being a positive
-!  value, the seawater-ice mixture is at thermodynamic equlibrium.
+!  value, the seawater-ice mixture is at thermodynamic equilibrium.
 !
 !  This code returns w_Ih_final = 0 when the input bulk enthalpy, h_bulk,
 !  is sufficiently large (i.e. sufficiently "warm") so that there is no ice
 !  present in the final state.  In this case the final state consists of
-!  only seawater rather than being an equlibrium mixture of seawater and
+!  only seawater rather than being an equilibrium mixture of seawater and
 !  ice which occurs when w_Ih_final is positive.  Note that when
 !  w_Ih_final = 0, the final seawater is not at the freezing temperature.
 !
@@ -5803,12 +5836,12 @@ elemental subroutine gsw_melting_ice_into_seawater (sa, ct, p, w_ih, t_ih,&
 !  This code takes the seawater to contain no dissolved air.
 !
 !  When the mass fraction w_Ih_final is calculated as being a positive
-!  value, the seawater-ice mixture is at thermodynamic equlibrium.
+!  value, the seawater-ice mixture is at thermodynamic equilibrium.
 !
 !  This code returns w_Ih_final = 0 when the input bulk enthalpy, h_bulk,
 !  is sufficiently large (i.e. sufficiently "warm") so that there is no ice
 !  present in the final state.  In this case the final state consists of
-!  only seawater rather than being an equlibrium mixture of seawater and
+!  only seawater rather than being an equilibrium mixture of seawater and
 !  ice which occurs when w_Ih_final is positive.  Note that when
 !  w_Ih_final = 0, the final seawater is not at the freezing temperature.
 !

--- a/src/c_gsw/gswteos-10.h
+++ b/src/c_gsw/gswteos-10.h
@@ -8,9 +8,15 @@
 #define GSWTEOS_10_H
 
 #ifdef __cplusplus
-#       include <complex>
+#   include <complex>
 #else
 #   include <complex.h>
+#endif
+
+#ifdef _WIN32
+#   define DECLSPEC __declspec(dllexport)
+#else
+#   define DECLSPEC
 #endif
 
 #ifdef __cplusplus
@@ -33,277 +39,278 @@ extern "C" {
 /*
 **  Prototypes:
 */
-extern void   gsw_add_barrier(double *input_data, double lon, double lat,
+DECLSPEC extern void   gsw_add_barrier(double *input_data, double lon, double lat,
                 double long_grid, double lat_grid, double dlong_grid,
                 double dlat_grid, double *output_data);
-extern void   gsw_add_mean(double *data_in, double *data_out);
-extern double gsw_adiabatic_lapse_rate_from_ct(double sa, double ct, double p);
-extern double gsw_adiabatic_lapse_rate_ice(double t, double p);
-extern double gsw_alpha(double sa, double ct, double p);
-extern double gsw_alpha_on_beta(double sa, double ct, double p);
-extern double gsw_alpha_wrt_t_exact(double sa, double t, double p);
-extern double gsw_alpha_wrt_t_ice(double t, double p);
-extern double gsw_beta_const_t_exact(double sa, double t, double p);
-extern double gsw_beta(double sa, double ct, double p);
-extern double gsw_cabbeling(double sa, double ct, double p);
-extern double gsw_c_from_sp(double sp, double t, double p);
-extern double gsw_chem_potential_water_ice(double t, double p);
-extern double gsw_chem_potential_water_t_exact(double sa, double t, double p);
-extern double gsw_cp_ice(double t, double p);
-extern double gsw_cp_t_exact(double sa, double t, double p);
-extern void   gsw_ct_first_derivatives (double sa, double pt, double *ct_sa,
+DECLSPEC extern void   gsw_add_mean(double *data_in, double *data_out);
+DECLSPEC extern int gsw_infunnel(double sa, double ct, double p);
+DECLSPEC extern double gsw_adiabatic_lapse_rate_from_ct(double sa, double ct, double p);
+DECLSPEC extern double gsw_adiabatic_lapse_rate_ice(double t, double p);
+DECLSPEC extern double gsw_alpha(double sa, double ct, double p);
+DECLSPEC extern double gsw_alpha_on_beta(double sa, double ct, double p);
+DECLSPEC extern double gsw_alpha_wrt_t_exact(double sa, double t, double p);
+DECLSPEC extern double gsw_alpha_wrt_t_ice(double t, double p);
+DECLSPEC extern double gsw_beta_const_t_exact(double sa, double t, double p);
+DECLSPEC extern double gsw_beta(double sa, double ct, double p);
+DECLSPEC extern double gsw_cabbeling(double sa, double ct, double p);
+DECLSPEC extern double gsw_c_from_sp(double sp, double t, double p);
+DECLSPEC extern double gsw_chem_potential_water_ice(double t, double p);
+DECLSPEC extern double gsw_chem_potential_water_t_exact(double sa, double t, double p);
+DECLSPEC extern double gsw_cp_ice(double t, double p);
+DECLSPEC extern double gsw_cp_t_exact(double sa, double t, double p);
+DECLSPEC extern void   gsw_ct_first_derivatives (double sa, double pt, double *ct_sa,
                 double *ct_pt);
-extern void   gsw_ct_first_derivatives_wrt_t_exact(double sa, double t,
+DECLSPEC extern void   gsw_ct_first_derivatives_wrt_t_exact(double sa, double t,
                 double p, double *ct_sa_wrt_t, double *ct_t_wrt_t,
                 double *ct_p_wrt_t);
-extern double gsw_ct_freezing(double sa, double p, double saturation_fraction);
-extern void   gsw_ct_freezing_first_derivatives(double sa, double p,
+DECLSPEC extern double gsw_ct_freezing(double sa, double p, double saturation_fraction);
+DECLSPEC extern void   gsw_ct_freezing_first_derivatives(double sa, double p,
                 double saturation_fraction, double *ctfreezing_sa,
                 double *ctfreezing_p);
-extern void   gsw_ct_freezing_first_derivatives_poly(double sa, double p,
+DECLSPEC extern void   gsw_ct_freezing_first_derivatives_poly(double sa, double p,
                 double saturation_fraction, double *ctfreezing_sa,
                 double *ctfreezing_p);
-extern double gsw_ct_freezing_poly(double sa, double p,
+DECLSPEC extern double gsw_ct_freezing_poly(double sa, double p,
                 double saturation_fraction);
-extern double gsw_ct_from_enthalpy(double sa, double h, double p);
-extern double gsw_ct_from_enthalpy_exact(double sa, double h, double p);
-extern double gsw_ct_from_entropy(double sa, double entropy);
-extern double gsw_ct_from_pt(double sa, double pt);
-extern void   gsw_ct_from_rho(double rho, double sa, double p, double *ct,
+DECLSPEC extern double gsw_ct_from_enthalpy(double sa, double h, double p);
+DECLSPEC extern double gsw_ct_from_enthalpy_exact(double sa, double h, double p);
+DECLSPEC extern double gsw_ct_from_entropy(double sa, double entropy);
+DECLSPEC extern double gsw_ct_from_pt(double sa, double pt);
+DECLSPEC extern void   gsw_ct_from_rho(double rho, double sa, double p, double *ct,
                 double *ct_multiple);
-extern double gsw_ct_from_t(double sa, double t, double p);
-extern double gsw_ct_maxdensity(double sa, double p);
-extern void   gsw_ct_second_derivatives(double sa, double pt, double *ct_sa_sa,
+DECLSPEC extern double gsw_ct_from_t(double sa, double t, double p);
+DECLSPEC extern double gsw_ct_maxdensity(double sa, double p);
+DECLSPEC extern void   gsw_ct_second_derivatives(double sa, double pt, double *ct_sa_sa,
                 double *ct_sa_pt, double *ct_pt_pt);
-extern double gsw_deltasa_atlas(double p, double lon, double lat);
-extern double gsw_deltasa_from_sp(double sp, double p, double lon, double lat);
-extern double gsw_dilution_coefficient_t_exact(double sa, double t, double p);
-extern double gsw_dynamic_enthalpy(double sa, double ct, double p);
-extern double gsw_enthalpy_ct_exact(double sa, double ct, double p);
-extern double gsw_enthalpy_diff(double sa, double ct, double p_shallow,
+DECLSPEC extern double gsw_deltasa_atlas(double p, double lon, double lat);
+DECLSPEC extern double gsw_deltasa_from_sp(double sp, double p, double lon, double lat);
+DECLSPEC extern double gsw_dilution_coefficient_t_exact(double sa, double t, double p);
+DECLSPEC extern double gsw_dynamic_enthalpy(double sa, double ct, double p);
+DECLSPEC extern double gsw_enthalpy_ct_exact(double sa, double ct, double p);
+DECLSPEC extern double gsw_enthalpy_diff(double sa, double ct, double p_shallow,
                 double p_deep);
-extern double gsw_enthalpy(double sa, double ct, double p);
-extern void   gsw_enthalpy_first_derivatives_ct_exact(double sa, double ct,
+DECLSPEC extern double gsw_enthalpy(double sa, double ct, double p);
+DECLSPEC extern void   gsw_enthalpy_first_derivatives_ct_exact(double sa, double ct,
                 double p, double *h_sa, double *h_ct);
-extern void   gsw_enthalpy_first_derivatives(double sa, double ct, double p,
+DECLSPEC extern void   gsw_enthalpy_first_derivatives(double sa, double ct, double p,
                 double *h_sa, double *h_ct);
-extern double gsw_enthalpy_ice(double t, double p);
-extern void   gsw_enthalpy_second_derivatives_ct_exact(double sa, double ct,
+DECLSPEC extern double gsw_enthalpy_ice(double t, double p);
+DECLSPEC extern void   gsw_enthalpy_second_derivatives_ct_exact(double sa, double ct,
                 double p, double *h_sa_sa, double *h_sa_ct, double *h_ct_ct);
-extern void   gsw_enthalpy_second_derivatives(double sa, double ct, double p,
+DECLSPEC extern void   gsw_enthalpy_second_derivatives(double sa, double ct, double p,
                 double *h_sa_sa, double *h_sa_ct, double *h_ct_ct);
-extern double gsw_enthalpy_sso_0(double p);
-extern double gsw_enthalpy_t_exact(double sa, double t, double p);
-extern void   gsw_entropy_first_derivatives(double sa, double ct,
+DECLSPEC extern double gsw_enthalpy_sso_0(double p);
+DECLSPEC extern double gsw_enthalpy_t_exact(double sa, double t, double p);
+DECLSPEC extern void   gsw_entropy_first_derivatives(double sa, double ct,
                 double *eta_sa, double *eta_ct);
-extern double gsw_entropy_from_ct(double sa, double ct);
-extern double gsw_entropy_from_pt(double sa, double pt);
-extern double gsw_entropy_from_t(double sa, double t, double p);
-extern double gsw_entropy_ice(double t, double p);
-extern double gsw_entropy_part(double sa, double t, double p);
-extern double gsw_entropy_part_zerop(double sa, double pt0);
-extern void   gsw_entropy_second_derivatives(double sa, double ct,
+DECLSPEC extern double gsw_entropy_from_ct(double sa, double ct);
+DECLSPEC extern double gsw_entropy_from_pt(double sa, double pt);
+DECLSPEC extern double gsw_entropy_from_t(double sa, double t, double p);
+DECLSPEC extern double gsw_entropy_ice(double t, double p);
+DECLSPEC extern double gsw_entropy_part(double sa, double t, double p);
+DECLSPEC extern double gsw_entropy_part_zerop(double sa, double pt0);
+DECLSPEC extern void   gsw_entropy_second_derivatives(double sa, double ct,
                 double *eta_sa_sa, double *eta_sa_ct, double *eta_ct_ct);
-extern double gsw_fdelta(double p, double lon, double lat);
-extern void   gsw_frazil_properties(double sa_bulk, double h_bulk, double p,
+DECLSPEC extern double gsw_fdelta(double p, double lon, double lat);
+DECLSPEC extern void   gsw_frazil_properties(double sa_bulk, double h_bulk, double p,
                 double *sa_final, double *ct_final, double *w_ih_final);
-extern void   gsw_frazil_properties_potential(double sa_bulk, double h_pot_bulk,
+DECLSPEC extern void   gsw_frazil_properties_potential(double sa_bulk, double h_pot_bulk,
                 double p, double *sa_final, double *ct_final,
                 double *w_ih_final);
-extern void   gsw_frazil_properties_potential_poly(double sa_bulk,
+DECLSPEC extern void   gsw_frazil_properties_potential_poly(double sa_bulk,
                 double h_pot_bulk, double p, double *sa_final, double *ct_final,
                 double *w_ih_final);
-extern void   gsw_frazil_ratios_adiabatic(double sa, double p, double w_ih,
+DECLSPEC extern void   gsw_frazil_ratios_adiabatic(double sa, double p, double w_ih,
                 double *dsa_dct_frazil, double *dsa_dp_frazil,
                 double *dct_dp_frazil);
-extern void   gsw_frazil_ratios_adiabatic_poly(double sa, double p,
+DECLSPEC extern void   gsw_frazil_ratios_adiabatic_poly(double sa, double p,
                 double w_ih, double *dsa_dct_frazil, double *dsa_dp_frazil,
                 double *dct_dp_frazil);
-extern double *gsw_geo_strf_dyn_height(double *sa, double *ct, double *p,
+DECLSPEC extern double *gsw_geo_strf_dyn_height(double *sa, double *ct, double *p,
                 double p_ref, int n_levels, double *dyn_height);
-extern int gsw_geo_strf_dyn_height_1(double *sa, double *ct, double *p,
+DECLSPEC extern int gsw_geo_strf_dyn_height_1(double *sa, double *ct, double *p,
                                 double p_ref, int n_levels, double *dyn_height,
                             double max_dp_i, int interp_method);
-extern double *gsw_geo_strf_dyn_height_pc(double *sa, double *ct,
+DECLSPEC extern double *gsw_geo_strf_dyn_height_pc(double *sa, double *ct,
                 double *delta_p, int n_levels, double *geo_strf_dyn_height_pc,
                 double *p_mid);
-extern double gsw_gibbs_ice (int nt, int np, double t, double p);
-extern double gsw_gibbs_ice_part_t(double t, double p);
-extern double gsw_gibbs_ice_pt0(double pt0);
-extern double gsw_gibbs_ice_pt0_pt0(double pt0);
-extern double gsw_gibbs(int ns, int nt, int np, double sa, double t, double p);
-extern double gsw_gibbs_pt0_pt0(double sa, double pt0);
-extern double gsw_grav(double lat, double p);
-extern double gsw_helmholtz_energy_ice(double t, double p);
-extern double gsw_hill_ratio_at_sp2(double t);
-extern void   gsw_ice_fraction_to_freeze_seawater(double sa, double ct,
+DECLSPEC extern double gsw_gibbs_ice (int nt, int np, double t, double p);
+DECLSPEC extern double gsw_gibbs_ice_part_t(double t, double p);
+DECLSPEC extern double gsw_gibbs_ice_pt0(double pt0);
+DECLSPEC extern double gsw_gibbs_ice_pt0_pt0(double pt0);
+DECLSPEC extern double gsw_gibbs(int ns, int nt, int np, double sa, double t, double p);
+DECLSPEC extern double gsw_gibbs_pt0_pt0(double sa, double pt0);
+DECLSPEC extern double gsw_grav(double lat, double p);
+DECLSPEC extern double gsw_helmholtz_energy_ice(double t, double p);
+DECLSPEC extern double gsw_hill_ratio_at_sp2(double t);
+DECLSPEC extern void   gsw_ice_fraction_to_freeze_seawater(double sa, double ct,
                 double p, double t_ih, double *sa_freeze, double *ct_freeze,
                 double *w_ih);
-extern double gsw_internal_energy(double sa, double ct, double p);
-extern double gsw_internal_energy_ice(double t, double p);
-extern void   gsw_ipv_vs_fnsquared_ratio(double *sa, double *ct, double *p,
+DECLSPEC extern double gsw_internal_energy(double sa, double ct, double p);
+DECLSPEC extern double gsw_internal_energy_ice(double t, double p);
+DECLSPEC extern void   gsw_ipv_vs_fnsquared_ratio(double *sa, double *ct, double *p,
                 double p_ref, int nz, double *ipv_vs_fnsquared_ratio,
                 double *p_mid);
-extern double gsw_kappa_const_t_ice(double t, double p);
-extern double gsw_kappa(double sa, double ct, double p);
-extern double gsw_kappa_ice(double t, double p);
-extern double gsw_kappa_t_exact(double sa, double t, double p);
-extern double gsw_latentheat_evap_ct(double sa, double ct);
-extern double gsw_latentheat_evap_t(double sa, double t);
-extern double gsw_latentheat_melting(double sa, double p);
-extern void   gsw_linear_interp_sa_ct(double *sa, double *ct, double *p, int np,
+DECLSPEC extern double gsw_kappa_const_t_ice(double t, double p);
+DECLSPEC extern double gsw_kappa(double sa, double ct, double p);
+DECLSPEC extern double gsw_kappa_ice(double t, double p);
+DECLSPEC extern double gsw_kappa_t_exact(double sa, double t, double p);
+DECLSPEC extern double gsw_latentheat_evap_ct(double sa, double ct);
+DECLSPEC extern double gsw_latentheat_evap_t(double sa, double t);
+DECLSPEC extern double gsw_latentheat_melting(double sa, double p);
+DECLSPEC extern void   gsw_linear_interp_sa_ct(double *sa, double *ct, double *p, int np,
                 double *p_i, int npi, double *sa_i, double *ct_i);
-extern double gsw_melting_ice_equilibrium_sa_ct_ratio(double sa, double p);
-extern double gsw_melting_ice_equilibrium_sa_ct_ratio_poly(double sa, double p);
-extern void   gsw_melting_ice_into_seawater(double sa, double ct, double p,
+DECLSPEC extern double gsw_melting_ice_equilibrium_sa_ct_ratio(double sa, double p);
+DECLSPEC extern double gsw_melting_ice_equilibrium_sa_ct_ratio_poly(double sa, double p);
+DECLSPEC extern void   gsw_melting_ice_into_seawater(double sa, double ct, double p,
                 double w_ih, double t_ih, double *sa_final, double *ct_final,
                 double *w_ih_final);
-extern double gsw_melting_ice_sa_ct_ratio(double sa, double ct, double p,
+DECLSPEC extern double gsw_melting_ice_sa_ct_ratio(double sa, double ct, double p,
                 double t_ih);
-extern double gsw_melting_ice_sa_ct_ratio_poly(double sa, double ct, double p,
+DECLSPEC extern double gsw_melting_ice_sa_ct_ratio_poly(double sa, double ct, double p,
                 double t_ih);
-extern double gsw_melting_seaice_equilibrium_sa_ct_ratio(double sa, double p);
-extern double gsw_melting_seaice_equilibrium_sa_ct_ratio_poly(double sa,
+DECLSPEC extern double gsw_melting_seaice_equilibrium_sa_ct_ratio(double sa, double p);
+DECLSPEC extern double gsw_melting_seaice_equilibrium_sa_ct_ratio_poly(double sa,
                 double p);
-extern void   gsw_melting_seaice_into_seawater(double sa, double ct, double p,
+DECLSPEC extern void   gsw_melting_seaice_into_seawater(double sa, double ct, double p,
                 double w_seaice, double sa_seaice, double t_seaice,
                 double *sa_final, double *ct_final);
-extern double gsw_melting_seaice_sa_ct_ratio(double sa, double ct, double p,
+DECLSPEC extern double gsw_melting_seaice_sa_ct_ratio(double sa, double ct, double p,
                 double sa_seaice, double t_seaice);
-extern double gsw_melting_seaice_sa_ct_ratio_poly(double sa, double ct,
+DECLSPEC extern double gsw_melting_seaice_sa_ct_ratio_poly(double sa, double ct,
                 double p, double sa_seaice, double t_seaice);
-extern void   gsw_nsquared(double *sa, double *ct, double *p, double *lat,
+DECLSPEC extern void   gsw_nsquared(double *sa, double *ct, double *p, double *lat,
                 int nz, double *n2, double *p_mid);
-extern double gsw_o2sol(double sa, double ct, double p, double lon, double lat);
-extern double gsw_o2sol_sp_pt(double sp, double pt);
-extern double gsw_pot_enthalpy_from_pt_ice(double pt0_ice);
-extern double gsw_pot_enthalpy_from_pt_ice_poly(double pt0_ice);
-extern double gsw_pot_enthalpy_ice_freezing(double sa, double p);
-extern void   gsw_pot_enthalpy_ice_freezing_first_derivatives(double sa,
+DECLSPEC extern double gsw_o2sol(double sa, double ct, double p, double lon, double lat);
+DECLSPEC extern double gsw_o2sol_sp_pt(double sp, double pt);
+DECLSPEC extern double gsw_pot_enthalpy_from_pt_ice(double pt0_ice);
+DECLSPEC extern double gsw_pot_enthalpy_from_pt_ice_poly(double pt0_ice);
+DECLSPEC extern double gsw_pot_enthalpy_ice_freezing(double sa, double p);
+DECLSPEC extern void   gsw_pot_enthalpy_ice_freezing_first_derivatives(double sa,
                 double p, double *pot_enthalpy_ice_freezing_sa,
                 double *pot_enthalpy_ice_freezing_p);
-extern void   gsw_pot_enthalpy_ice_freezing_first_derivatives_poly(double sa,
+DECLSPEC extern void   gsw_pot_enthalpy_ice_freezing_first_derivatives_poly(double sa,
                 double p, double *pot_enthalpy_ice_freezing_sa,
                 double *pot_enthalpy_ice_freezing_p);
-extern double gsw_pot_enthalpy_ice_freezing_poly(double sa, double p);
-extern double gsw_pot_rho_t_exact(double sa, double t, double p, double p_ref);
-extern double gsw_pressure_coefficient_ice(double t, double p);
-extern double gsw_pressure_freezing_ct(double sa, double ct,
+DECLSPEC extern double gsw_pot_enthalpy_ice_freezing_poly(double sa, double p);
+DECLSPEC extern double gsw_pot_rho_t_exact(double sa, double t, double p, double p_ref);
+DECLSPEC extern double gsw_pressure_coefficient_ice(double t, double p);
+DECLSPEC extern double gsw_pressure_freezing_ct(double sa, double ct,
                 double saturation_fraction);
-extern double gsw_pt0_cold_ice_poly(double pot_enthalpy_ice);
-extern double gsw_pt0_from_t(double sa, double t, double p);
-extern double gsw_pt0_from_t_ice(double t, double p);
-extern void   gsw_pt_first_derivatives (double sa, double ct, double *pt_sa,
+DECLSPEC extern double gsw_pt0_cold_ice_poly(double pot_enthalpy_ice);
+DECLSPEC extern double gsw_pt0_from_t(double sa, double t, double p);
+DECLSPEC extern double gsw_pt0_from_t_ice(double t, double p);
+DECLSPEC extern void   gsw_pt_first_derivatives (double sa, double ct, double *pt_sa,
                 double *pt_ct);
-extern double gsw_pt_from_ct(double sa, double ct);
-extern double gsw_pt_from_entropy(double sa, double entropy);
-extern double gsw_pt_from_pot_enthalpy_ice(double pot_enthalpy_ice);
-extern double gsw_pt_from_pot_enthalpy_ice_poly_dh(double pot_enthalpy_ice);
-extern double gsw_pt_from_pot_enthalpy_ice_poly(double pot_enthalpy_ice);
-extern double gsw_pt_from_t(double sa, double t, double p, double p_ref);
-extern double gsw_pt_from_t_ice(double t, double p, double p_ref);
-extern void   gsw_pt_second_derivatives (double sa, double ct, double *pt_sa_sa,
+DECLSPEC extern double gsw_pt_from_ct(double sa, double ct);
+DECLSPEC extern double gsw_pt_from_entropy(double sa, double entropy);
+DECLSPEC extern double gsw_pt_from_pot_enthalpy_ice(double pot_enthalpy_ice);
+DECLSPEC extern double gsw_pt_from_pot_enthalpy_ice_poly_dh(double pot_enthalpy_ice);
+DECLSPEC extern double gsw_pt_from_pot_enthalpy_ice_poly(double pot_enthalpy_ice);
+DECLSPEC extern double gsw_pt_from_t(double sa, double t, double p, double p_ref);
+DECLSPEC extern double gsw_pt_from_t_ice(double t, double p, double p_ref);
+DECLSPEC extern void   gsw_pt_second_derivatives (double sa, double ct, double *pt_sa_sa,
                 double *pt_sa_ct, double *pt_ct_ct);
-extern void   gsw_rho_alpha_beta (double sa, double ct, double p, double *rho,
+DECLSPEC extern void   gsw_rho_alpha_beta (double sa, double ct, double p, double *rho,
                 double *alpha, double *beta);
-extern double gsw_rho(double sa, double ct, double p);
-extern void   gsw_rho_first_derivatives(double sa, double ct, double p,
+DECLSPEC extern double gsw_rho(double sa, double ct, double p);
+DECLSPEC extern void   gsw_rho_first_derivatives(double sa, double ct, double p,
                 double *drho_dsa, double *drho_dct, double *drho_dp);
-extern void   gsw_rho_first_derivatives_wrt_enthalpy (double sa, double ct,
+DECLSPEC extern void   gsw_rho_first_derivatives_wrt_enthalpy (double sa, double ct,
                 double p, double *rho_sa, double *rho_h);
-extern double gsw_rho_ice(double t, double p);
-extern void   gsw_rho_second_derivatives(double sa, double ct, double p,
+DECLSPEC extern double gsw_rho_ice(double t, double p);
+DECLSPEC extern void   gsw_rho_second_derivatives(double sa, double ct, double p,
                 double *rho_sa_sa, double *rho_sa_ct, double *rho_ct_ct,
                 double *rho_sa_p, double *rho_ct_p);
-extern void   gsw_rho_second_derivatives_wrt_enthalpy(double sa, double ct,
+DECLSPEC extern void   gsw_rho_second_derivatives_wrt_enthalpy(double sa, double ct,
                 double p, double *rho_sa_sa, double *rho_sa_h, double *rho_h_h);
-extern double gsw_rho_t_exact(double sa, double t, double p);
-extern void   gsw_rr68_interp_sa_ct(double *sa, double *ct, double *p, int mp,
+DECLSPEC extern double gsw_rho_t_exact(double sa, double t, double p);
+DECLSPEC extern void   gsw_rr68_interp_sa_ct(double *sa, double *ct, double *p, int mp,
                 double *p_i, int mp_i, double *sa_i, double *ct_i);
-extern double gsw_saar(double p, double lon, double lat);
-extern double gsw_sa_freezing_estimate(double p, double saturation_fraction,
+DECLSPEC extern double gsw_saar(double p, double lon, double lat);
+DECLSPEC extern double gsw_sa_freezing_estimate(double p, double saturation_fraction,
                 double *ct, double *t);
-extern double gsw_sa_freezing_from_ct(double ct, double p,
+DECLSPEC extern double gsw_sa_freezing_from_ct(double ct, double p,
                 double saturation_fraction);
-extern double gsw_sa_freezing_from_ct_poly(double ct, double p,
+DECLSPEC extern double gsw_sa_freezing_from_ct_poly(double ct, double p,
                 double saturation_fraction);
-extern double gsw_sa_freezing_from_t(double t, double p,
+DECLSPEC extern double gsw_sa_freezing_from_t(double t, double p,
                 double saturation_fraction);
-extern double gsw_sa_freezing_from_t_poly(double t, double p,
+DECLSPEC extern double gsw_sa_freezing_from_t_poly(double t, double p,
                 double saturation_fraction);
-extern double gsw_sa_from_rho(double rho, double ct, double p);
-extern double gsw_sa_from_sp_baltic(double sp, double lon, double lat);
-extern double gsw_sa_from_sp(double sp, double p, double lon, double lat);
-extern double gsw_sa_from_sstar(double sstar, double p,double lon,double lat);
-extern int    gsw_sa_p_inrange(double sa, double p);
-extern void   gsw_seaice_fraction_to_freeze_seawater(double sa, double ct,
+DECLSPEC extern double gsw_sa_from_rho(double rho, double ct, double p);
+DECLSPEC extern double gsw_sa_from_sp_baltic(double sp, double lon, double lat);
+DECLSPEC extern double gsw_sa_from_sp(double sp, double p, double lon, double lat);
+DECLSPEC extern double gsw_sa_from_sstar(double sstar, double p,double lon,double lat);
+DECLSPEC extern int    gsw_sa_p_inrange(double sa, double p);
+DECLSPEC extern void   gsw_seaice_fraction_to_freeze_seawater(double sa, double ct,
                 double p, double sa_seaice, double t_seaice, double *sa_freeze,
                 double *ct_freeze, double *w_seaice);
-extern double gsw_sigma0(double sa, double ct);
-extern double gsw_sigma1(double sa, double ct);
-extern double gsw_sigma2(double sa, double ct);
-extern double gsw_sigma3(double sa, double ct);
-extern double gsw_sigma4(double sa, double ct);
-extern double gsw_sound_speed(double sa, double ct, double p);
-extern double gsw_sound_speed_ice(double t, double p);
-extern double gsw_sound_speed_t_exact(double sa, double t, double p);
-extern void   gsw_specvol_alpha_beta(double sa, double ct, double p,
+DECLSPEC extern double gsw_sigma0(double sa, double ct);
+DECLSPEC extern double gsw_sigma1(double sa, double ct);
+DECLSPEC extern double gsw_sigma2(double sa, double ct);
+DECLSPEC extern double gsw_sigma3(double sa, double ct);
+DECLSPEC extern double gsw_sigma4(double sa, double ct);
+DECLSPEC extern double gsw_sound_speed(double sa, double ct, double p);
+DECLSPEC extern double gsw_sound_speed_ice(double t, double p);
+DECLSPEC extern double gsw_sound_speed_t_exact(double sa, double t, double p);
+DECLSPEC extern void   gsw_specvol_alpha_beta(double sa, double ct, double p,
                 double *specvol, double *alpha, double *beta);
-extern double gsw_specvol_anom_standard(double sa, double ct, double p);
-extern double gsw_specvol(double sa, double ct, double p);
-extern void   gsw_specvol_first_derivatives(double sa, double ct, double p,
+DECLSPEC extern double gsw_specvol_anom_standard(double sa, double ct, double p);
+DECLSPEC extern double gsw_specvol(double sa, double ct, double p);
+DECLSPEC extern void   gsw_specvol_first_derivatives(double sa, double ct, double p,
                 double *v_sa, double *v_ct, double *v_p);
-extern void   gsw_specvol_first_derivatives_wrt_enthalpy(double sa, double ct,
+DECLSPEC extern void   gsw_specvol_first_derivatives_wrt_enthalpy(double sa, double ct,
                 double p, double *v_sa, double *v_h);
-extern double gsw_specvol_ice(double t, double p);
-extern void   gsw_specvol_second_derivatives (double sa, double ct, double p,
+DECLSPEC extern double gsw_specvol_ice(double t, double p);
+DECLSPEC extern void   gsw_specvol_second_derivatives (double sa, double ct, double p,
                 double *v_sa_sa, double *v_sa_ct, double *v_ct_ct,
                 double *v_sa_p, double *v_ct_p);
-extern void   gsw_specvol_second_derivatives_wrt_enthalpy(double sa, double ct,
+DECLSPEC extern void   gsw_specvol_second_derivatives_wrt_enthalpy(double sa, double ct,
                 double p, double *v_sa_sa, double *v_sa_h, double *v_h_h);
-extern double gsw_specvol_sso_0(double p);
-extern double gsw_specvol_t_exact(double sa, double t, double p);
-extern double gsw_sp_from_c(double c, double t, double p);
-extern double gsw_sp_from_sa_baltic(double sa, double lon, double lat);
-extern double gsw_sp_from_sa(double sa, double p, double lon, double lat);
-extern double gsw_sp_from_sk(double sk);
-extern double gsw_sp_from_sr(double sr);
-extern double gsw_sp_from_sstar(double sstar, double p,double lon,double lat);
-extern double gsw_sp_salinometer(double rt, double t);
-extern double gsw_spiciness0(double sa, double ct);
-extern double gsw_spiciness1(double sa, double ct);
-extern double gsw_spiciness2(double sa, double ct);
-extern double gsw_sr_from_sp(double sp);
-extern double gsw_sstar_from_sa(double sa, double p, double lon, double lat);
-extern double gsw_sstar_from_sp(double sp, double p, double lon, double lat);
-extern double gsw_t_deriv_chem_potential_water_t_exact(double sa, double t,
+DECLSPEC extern double gsw_specvol_sso_0(double p);
+DECLSPEC extern double gsw_specvol_t_exact(double sa, double t, double p);
+DECLSPEC extern double gsw_sp_from_c(double c, double t, double p);
+DECLSPEC extern double gsw_sp_from_sa_baltic(double sa, double lon, double lat);
+DECLSPEC extern double gsw_sp_from_sa(double sa, double p, double lon, double lat);
+DECLSPEC extern double gsw_sp_from_sk(double sk);
+DECLSPEC extern double gsw_sp_from_sr(double sr);
+DECLSPEC extern double gsw_sp_from_sstar(double sstar, double p,double lon,double lat);
+DECLSPEC extern double gsw_sp_salinometer(double rt, double t);
+DECLSPEC extern double gsw_spiciness0(double sa, double ct);
+DECLSPEC extern double gsw_spiciness1(double sa, double ct);
+DECLSPEC extern double gsw_spiciness2(double sa, double ct);
+DECLSPEC extern double gsw_sr_from_sp(double sp);
+DECLSPEC extern double gsw_sstar_from_sa(double sa, double p, double lon, double lat);
+DECLSPEC extern double gsw_sstar_from_sp(double sp, double p, double lon, double lat);
+DECLSPEC extern double gsw_t_deriv_chem_potential_water_t_exact(double sa, double t,
                 double p);
-extern double gsw_t_freezing(double sa, double p, double saturation_fraction);
-extern void   gsw_t_freezing_first_derivatives_poly(double sa, double p,
+DECLSPEC extern double gsw_t_freezing(double sa, double p, double saturation_fraction);
+DECLSPEC extern void   gsw_t_freezing_first_derivatives_poly(double sa, double p,
                 double saturation_fraction, double *tfreezing_sa,
                 double *tfreezing_p);
-extern void   gsw_t_freezing_first_derivatives(double sa, double p,
+DECLSPEC extern void   gsw_t_freezing_first_derivatives(double sa, double p,
                 double saturation_fraction, double *tfreezing_sa,
                 double *tfreezing_p);
-extern double gsw_t_freezing_poly(double sa, double p,
+DECLSPEC extern double gsw_t_freezing_poly(double sa, double p,
                 double saturation_fraction);
-extern double gsw_t_from_ct(double sa, double ct, double p);
-extern double gsw_t_from_pt0_ice(double pt0_ice, double p);
-extern double gsw_thermobaric(double sa, double ct, double p);
-extern void   gsw_turner_rsubrho(double *sa, double *ct, double *p, int nz,
+DECLSPEC extern double gsw_t_from_ct(double sa, double ct, double p);
+DECLSPEC extern double gsw_t_from_pt0_ice(double pt0_ice, double p);
+DECLSPEC extern double gsw_thermobaric(double sa, double ct, double p);
+DECLSPEC extern void   gsw_turner_rsubrho(double *sa, double *ct, double *p, int nz,
                 double *tu, double *rsubrho, double *p_mid);
-extern int    gsw_util_indx(double *x, int n, double z);
-extern double *gsw_util_interp1q_int(int nx, double *x, int *iy, int nxi,
+DECLSPEC extern int    gsw_util_indx(double *x, int n, double z);
+DECLSPEC extern double *gsw_util_interp1q_int(int nx, double *x, int *iy, int nxi,
                 double *x_i, double *y_i);
-extern double *gsw_util_linear_interp(int nx, double *x, int ny, double *y,
+DECLSPEC extern double *gsw_util_linear_interp(int nx, double *x, int ny, double *y,
                 int nxi, double *x_i, double *y_i);
-extern void   gsw_util_sort_real(double *rarray, int nx, int *iarray);
-extern double gsw_util_xinterp1(double *x, double *y, int n, double x0);
-extern int gsw_util_pchip_interp(double *x, double *y, int n,
+DECLSPEC extern void   gsw_util_sort_real(double *rarray, int nx, int *iarray);
+DECLSPEC extern double gsw_util_xinterp1(double *x, double *y, int n, double x0);
+DECLSPEC extern int gsw_util_pchip_interp(double *x, double *y, int n,
                 double *xi, double *yi, int ni);
-extern double gsw_z_from_p(double p, double lat, double geo_strf_dyn_height,
+DECLSPEC extern double gsw_z_from_p(double p, double lat, double geo_strf_dyn_height,
                 double sea_surface_geopotential);
-extern double gsw_p_from_z(double z, double lat, double geo_strf_dyn_height,
+DECLSPEC extern double gsw_p_from_z(double z, double lat, double geo_strf_dyn_height,
                 double sea_surface_geopotential);
 
 #ifdef __cplusplus


### PR DESCRIPTION
This is in response to https://github.com/geoffstanley/neutralocean/issues/15.

Prior to this PR, direct access to the C functions via ctypes worked only on Linux and Mac.  This PR makes it work on Windows.  A simple test is included. The change is propagated back to GSW-C by https://github.com/TEOS-10/GSW-C/pull/69.

The update from GSW-C also pulls in the new C "infunnel" function which will require significant work to wrap, either by modifying the automated wrapping machinery or by making a one-off wrapper for it.  That is left for a subsequent PR.