### PR TITLE
Fix rho units in two docstrings

### DIFF
--- a/gsw/_wrapped_ufuncs.py
+++ b/gsw/_wrapped_ufuncs.py
@@ -5135,7 +5135,7 @@ def rho(SA, CT, p):
 
     Returns
     -------
-    rho : array-like, kg/m
+    rho : array-like, kg/m^3
         in-situ density
 
 
@@ -5194,7 +5194,7 @@ def rho_alpha_beta(SA, CT, p):
 
     Returns
     -------
-    rho : array-like, kg/m
+    rho : array-like, kg/m^3
         in-situ density
     alpha : array-like, 1/K
         thermal expansion coefficient

--- a/tools/fix_wrapped_ufunc_typos.py
+++ b/tools/fix_wrapped_ufunc_typos.py
@@ -36,6 +36,7 @@ subs = [
     ('equlibrium', 'equilibrium'),
     (' apendix ', ' appendix '),
     (' slighty ', ' slightly '),
+    ('rho : array-like, kg/m', 'rho : array-like, kg/m^3'),
 ]
 
 with open(wrapmod) as f:


### PR DESCRIPTION
Closes #178.

From the Matlab version we inherit incorrect units in the docstring return values for rho, in two functions.  It is fixed here by adding one more substitution to the list in tools/fix_wrapped_ufunc_typos.py.  Some day, all of those fixes might be applied to the Matlab version from which we get the docstrings, but until then, our current fixup mechanism is adequate.