### PR TITLE
Fix micromamba

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,3 +9,7 @@ updates:
       interval: "daily"
     labels:
       - "Bot"
+    groups:
+      github-actions:
+        patterns:
+          - '*'

--- a/.github/workflows/test_code_generation.yml
+++ b/.github/workflows/test_code_generation.yml
@@ -5,30 +5,26 @@ on:
   push:
     branches: [main]
 
+defaults:
+  run:
+    shell: bash
+
 jobs:
   code-generation:
     runs-on: ubuntu-latest
-    defaults:
-      run:
-        shell: bash -l {0}
 
     steps:
-    - name: checkout
-      uses: actions/checkout@v4
-      with:
-        fetch-depth: 0
+    - uses: actions/checkout@v4
 
-    - name: Setup Micromamba
-      uses: mamba-org/setup-micromamba@v2
+    - name: Set up Python
+      uses: actions/setup-python@v5
       with:
-        environment-name: TEST
-        init-shell: bash
-        create-args: >-
-          python=3
-          python-build
-          numpy
-          --file requirements-dev.txt
-          --channel conda-forge
+        python-version: "3.x"
+
+    - name: Install gsw
+      run: >
+        python -m pip install -r requirements-dev.txt
+        && python -m pip install -e .
 
     - name: Test Code Generation
       run: >

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -16,6 +16,9 @@ jobs:
       matrix:
         python-version: [ "3.9", "3.10", "3.11", "3.12" ]
         os: [ windows-latest, ubuntu-latest, macos-latest ]
+        # Oldest one based on NEP-29 and latest one.
+        # See https://numpy.org/neps/nep-0029-deprecation_policy.html
+        numpy-version: ["1.23", "1.26"]
       fail-fast: false
 
     steps:
@@ -30,6 +33,7 @@ jobs:
       run: >
         python -m pip install -r requirements-dev.txt
         && python -m pip install -e .
+        && python -m pip install numpy==${{ matrix.numpy-version }}
 
     - name: Tests
       run: |

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -5,6 +5,10 @@ on:
   push:
     branches: [main]
 
+defaults:
+  run:
+    shell: bash
+
 jobs:
   run:
     runs-on: ${{ matrix.os }}
@@ -12,31 +16,20 @@ jobs:
       matrix:
         python-version: [ "3.9", "3.10", "3.11", "3.12" ]
         os: [ windows-latest, ubuntu-latest, macos-latest ]
-        # Oldest one based on NEP-29 and latest one.
-        # See https://numpy.org/neps/nep-0029-deprecation_policy.html
-        numpy-version: ["1.23", "1.26"]
-        exclude:
-          - python-version: "3.12"
-            numpy-version: "1.23"
       fail-fast: false
-    defaults:
-      run:
-        shell: bash -l {0}
 
     steps:
     - uses: actions/checkout@v4
 
-    - name: Setup Micromamba Python ${{ matrix.python-version }} numpy ${{ matrix.numpy-version }}
-      uses: mamba-org/setup-micromamba@v2
+    - name: Set up Python
+      uses: actions/setup-python@v5
       with:
-        environment-name: TEST
-        init-shell: bash
-        create-args: >-
-          python=${{ matrix.python-version }} python-build numpy=${{ matrix.numpy-version }} --file requirements-dev.txt --channel conda-forge
+        python-version: ${{ matrix.python-version }}
 
     - name: Install gsw
-      run: |
-        python -m pip install -e . --no-deps --force-reinstall
+      run: >
+        python -m pip install -r requirements-dev.txt
+        && python -m pip install -e .
 
     - name: Tests
       run: |

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -16,9 +16,11 @@ jobs:
       matrix:
         python-version: [ "3.9", "3.10", "3.11", "3.12" ]
         os: [ windows-latest, ubuntu-latest, macos-latest ]
-        # Oldest one based on NEP-29 and latest one.
-        # See https://numpy.org/neps/nep-0029-deprecation_policy.html
-        numpy-version: ["1.23", "1.26"]
+        # https://scientific-python.org/specs/spec-0000/
+        numpy-version: ["==1.24", ">=2"]
+        exclude:
+          - python-version: "3.12"
+            numpy-version: "==1.24"
       fail-fast: false
 
     steps:
@@ -33,7 +35,7 @@ jobs:
       run: >
         python -m pip install -r requirements-dev.txt
         && python -m pip install -e .
-        && python -m pip install numpy==${{ matrix.numpy-version }}
+        && python -m pip install numpy${{ matrix.numpy-version }}
 
     - name: Tests
       run: |


### PR DESCRIPTION
Ever since release 2.0 we are having regressions that are taking a lot of dev time to fix. Let's remove micromamba from the setup for now and, when we really need conda packages, we can try pixi instead.