### PR TITLE
Fix constant integration offset in geo_strf_dyn_height

### DIFF
--- a/gsw/geostrophy.py
+++ b/gsw/geostrophy.py
@@ -98,6 +98,10 @@ def geo_strf_dyn_height(SA, CT, p, p_ref=0, axis=0, max_dp=1.0,
             dh_all = _gsw_ufuncs.geo_strf_dyn_height_1(
                                          sa, ct, pgood, p_ref, max_dp,
                                          interp_methods[interp_method])
+            # Force dynamic height to be exactly zero at the reference pressure
+            iref = np.where(np.isclose(pgood, p_ref))[0]
+            if len(iref) > 0:
+                dh_all = dh_all - dh_all[iref[0]]
             if ntop > 0:
                 dh[ind][igood] = dh_all[ntop:]
             else:


### PR DESCRIPTION
This pull request ensures that `geo_strf_dyn_height` returns a dynamic height anomaly that is exactly zero at the reference pressure (`p_ref`).

In the MATLAB GSW toolbox, the dynamic height is explicitly anchored by subtracting its value at `p_ref`, ensuring:

```MATLAB
dh(p_ref) = 0
```

In the current Python implementation, a constant integration offset may remain due to the implicit integration constant of the numerical integral. As a result, the dynamic height at `p_ref` can differ from zero even when `p_ref` is included in the integration grid.

This modification removes that constant by subtracting the dynamic height evaluated at `p_ref` within each processed profile.

This prevents discrepancies between MATLAB and Python implementations when comparing dynamic height or derived quantities.